### PR TITLE
Migrate to "Annotations as Options"

### DIFF
--- a/src/main/scala/treadle/Driver.scala
+++ b/src/main/scala/treadle/Driver.scala
@@ -2,31 +2,49 @@
 
 package treadle
 
-import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
+import firrtl.{ExecutionOptionsManager, HasFirrtlExecutionOptions, FirrtlSourceAnnotation}
+import firrtl.annotations.{Annotation, NoTargetAnnotation, SingleStringAnnotation}
 import treadle.executable.ClockInfo
+
+sealed trait TreadleOption { self: Annotation => }
+case object WriteVcdAnnotation extends NoTargetAnnotation with TreadleOption
+case object VcdShowUnderscoredAnnotation extends NoTargetAnnotation with TreadleOption
+case object VerboseAnnotation extends NoTargetAnnotation with TreadleOption
+case object SetOrderedExecAnnotation extends NoTargetAnnotation with TreadleOption
+case object AllowCyclesAnnotation extends NoTargetAnnotation with TreadleOption
+case class RandomSeedAnnotation(value: Long) extends NoTargetAnnotation with TreadleOption
+case class BlackBoxFactoryAnnotation(value: BlackBoxFactory) extends NoTargetAnnotation with TreadleOption
+case class MaxExecutionDepthAnnotation(value: Long) extends NoTargetAnnotation with TreadleOption
+case object ShowFirrtlAtLoadAnnotation extends NoTargetAnnotation with TreadleOption
+case object LowCompileAtLoadAnnotation extends NoTargetAnnotation with TreadleOption
+case object ValidIfIsRandomAnnotation extends NoTargetAnnotation with TreadleOption
+case class RollbackBuffersAnnotation(value: Int) extends NoTargetAnnotation with TreadleOption
+case class ClockInfoAnnotation(value: ClockInfo) extends NoTargetAnnotation with TreadleOption
+case class ResetNameAnnotation(value: String) extends SingleStringAnnotation with TreadleOption
+case object NoDefaultResetAnnotation extends NoTargetAnnotation with TreadleOption
+case class SymbolToWatchAnnotation(value: String) extends SingleStringAnnotation with TreadleOption
 
 //scalastyle:off magic.number
 case class TreadleOptions(
-    writeVCD           : Boolean              = false,
-    vcdShowUnderscored : Boolean              = false,
-    setVerbose         : Boolean              = false,
-    setOrderedExec     : Boolean              = false,
-    allowCycles        : Boolean              = false,
-    randomSeed         : Long                 = System.currentTimeMillis(),
-    blackBoxFactories  : Seq[BlackBoxFactory] = Seq.empty,
-    maxExecutionDepth  : Long                 = Int.MaxValue,
-    showFirrtlAtLoad   : Boolean              = false,
-    lowCompileAtLoad   : Boolean              = true,
-    validIfIsRandom    : Boolean              = false,
-    rollbackBuffers    : Int                  = 4,
-    clockInfo          : Seq[ClockInfo]       = Seq.empty,
-    resetName          : String               = "reset",
-    noDefaultReset     : Boolean              = false,
-    symbolsToWatch     : Seq[String]          = Seq.empty
-  )
-  extends firrtl.ComposableOptions {
+  writeVCD           : Boolean              = false,
+  vcdShowUnderscored : Boolean              = false,
+  setVerbose         : Boolean              = false,
+  setOrderedExec     : Boolean              = false,
+  allowCycles        : Boolean              = false,
+  randomSeed         : Long                 = System.currentTimeMillis(),
+  blackBoxFactories  : Seq[BlackBoxFactory] = Seq.empty,
+  maxExecutionDepth  : Long                 = Int.MaxValue,
+  showFirrtlAtLoad   : Boolean              = false,
+  lowCompileAtLoad   : Boolean              = true,
+  validIfIsRandom    : Boolean              = false,
+  rollbackBuffers    : Int                  = 4,
+  clockInfo          : Seq[ClockInfo]       = Seq.empty,
+  resetName          : String               = "reset",
+  noDefaultReset     : Boolean              = false,
+  symbolsToWatch     : Seq[String]          = Seq.empty
+) {
 
-  def vcdOutputFileName(optionsManager: ExecutionOptionsManager): String = {
+  def vcdOutputFileName(optionsManager: ExecutionOptionsManager with HasFirrtlExecutionOptions): String = {
     if(writeVCD) {
       s"${optionsManager.getBuildFileName("vcd")}"
     }
@@ -39,88 +57,94 @@ case class TreadleOptions(
 trait HasTreadleOptions {
   self: ExecutionOptionsManager =>
 
-  var treadleOptions = TreadleOptions()
+  lazy val treadleOptions: TreadleOptions = options
+    .collect{ case t: TreadleOption => t }
+    .foldLeft(TreadleOptions())( (t, x) =>
+      x match {
+        case WriteVcdAnnotation             => t.copy(writeVCD = true)
+        case VcdShowUnderscoredAnnotation   => t.copy(vcdShowUnderscored = true)
+        case VerboseAnnotation              => t.copy(setVerbose = true)
+        case SetOrderedExecAnnotation       => t.copy(setOrderedExec = true)
+        case AllowCyclesAnnotation          => t.copy(allowCycles = true)
+        case RandomSeedAnnotation(s)        => t.copy(randomSeed = s)
+        case BlackBoxFactoryAnnotation(b)   => t.copy(blackBoxFactories = t.blackBoxFactories :+ b)
+        case MaxExecutionDepthAnnotation(d) => t.copy(maxExecutionDepth = d)
+        case ShowFirrtlAtLoadAnnotation     => t.copy(showFirrtlAtLoad = true)
+        case LowCompileAtLoadAnnotation     => t.copy(lowCompileAtLoad = false)
+        case ValidIfIsRandomAnnotation      => t.copy(validIfIsRandom = true)
+        case RollbackBuffersAnnotation(r)   => t.copy(rollbackBuffers = r)
+        case ClockInfoAnnotation(i)         => t.copy(clockInfo = t.clockInfo :+ i)
+        case ResetNameAnnotation(n)         => t.copy(resetName = n)
+        case NoDefaultResetAnnotation       => t.copy(noDefaultReset = true)
+        case SymbolToWatchAnnotation(s)     => t.copy(symbolsToWatch = t.symbolsToWatch :+ s)
+      }
+    )
 
   parser.note("firrtl-engine-options")
 
   parser.opt[Unit]("fint-write-vcd")
     .abbr("fiwv")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(writeVCD = true)
-    }
+    .action( (_, a) => a :+ WriteVcdAnnotation )
     .text("writes vcd execution log, filename will be base on top")
 
   parser.opt[Unit]("fint-vcd-show-underscored-vars")
     .abbr("fivsuv")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(vcdShowUnderscored = true)
-    }
+    .action( (_, a) => a :+ VcdShowUnderscoredAnnotation )
     .text("vcd output by default does not show var that start with underscore, this overrides that")
 
   parser.opt[Unit]("fint-verbose")
     .abbr("fiv")
-    .foreach {_ =>
-      treadleOptions = treadleOptions.copy(setVerbose = true)
-    }
+    .action( (_, a) => a :+ VerboseAnnotation )
     .text("makes engine very verbose")
 
   parser.opt[Unit]("fint-ordered-exec")
     .abbr("fioe")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(setOrderedExec = true)
-    }
+    .action( (_, a) => a :+ SetOrderedExecAnnotation )
     .text("operates on dependencies optimally, can increase overhead, makes verbose mode easier to read")
 
   parser.opt[Unit]("fr-allow-cycles")
     .abbr("fiac")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(allowCycles = true)
-    }
-    .text(s"allow combinational loops to be processed, though unreliable, default is ${treadleOptions.allowCycles}")
+    .action( (_, a) => a :+ AllowCyclesAnnotation )
+    .text(s"allow combinational loops to be processed, though unreliable, default is ${new TreadleOptions().allowCycles}")
 
   parser.opt[Long]("fint-random-seed")
     .abbr("firs")
-      .valueName("<long-value>")
-    .foreach { x =>
-      treadleOptions = treadleOptions.copy(randomSeed = x)
-    }
+    .valueName("<long-value>")
+    .action( (x, a) => a :+ RandomSeedAnnotation(x) )
     .text("seed used for random numbers generated for tests and poison values, default is current time in ms")
+
+  parser.opt[String]("blackbox-factory")
+    .action( (x, a) => try {
+              a :+ BlackBoxFactoryAnnotation(Class.forName(x).asInstanceOf[Class[_<:BlackBoxFactory]].newInstance())
+            } catch {
+              case e: ClassNotFoundException => throw TreadleException(s"Unable to find class '$x' (did you misspell it?)")
+            })
+    .text("A class (with full path) that provides black box implementations")
+
+  parser.opt[Long]("max-execution-depth")
+    .action( (x, a) => a :+ MaxExecutionDepthAnnotation(x) )
+    .text(s"maximum execution depth (default: ${new TreadleOptions().maxExecutionDepth})")
 
   parser.opt[Unit]("show-firrtl-at-load")
     .abbr("fisfas")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(showFirrtlAtLoad = true)
-    }
+    .action( (_, a) => a :+ ShowFirrtlAtLoadAnnotation )
     .text("compiled low firrtl at firrtl load time")
 
   parser.opt[Unit]("dont-run-lower-compiler-on-load")
     .abbr("filcol")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(lowCompileAtLoad = false)
-    }
+    .action( (_, a) => a :+ LowCompileAtLoadAnnotation )
     .text("run lowering compiler when firrtl file is loaded")
 
   parser.opt[Unit]("validif-random")
     .abbr("fivir")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(validIfIsRandom = true)
-    }
+    .action( (_, a) => a :+ ValidIfIsRandomAnnotation )
     .text("validIf returns random value when condition is false")
-
-  parser.opt[Unit]("no-default-reset")
-    .abbr("findr")
-    .foreach { _ =>
-      treadleOptions = treadleOptions.copy(noDefaultReset = true)
-    }
-    .text("this prevents the tester from doing reset on it's own at startup")
 
   parser.opt[Int]("fint-rollback-buffers")
     .abbr("firb")
     .valueName("<int-value>")
-    .foreach { x =>
-      treadleOptions = treadleOptions.copy(rollbackBuffers = x)
-    }
-    .text("number of rollback buffers, 0 is no buffers, default is 4")
+    .action( (x, a) => a :+ RollbackBuffersAnnotation(x) )
+    .text(s"number of rollback buffers, 0 is no buffers, (default: ${new TreadleOptions().rollbackBuffers})")
 
   def parseClockInfo(input: String): ClockInfo = {
     input.split(":").map(_.trim).toList match {
@@ -138,40 +162,50 @@ trait HasTreadleOptions {
     .abbr("fici")
     .unbounded()
     .valueName("<string>")
-    .foreach { x =>
-      treadleOptions = treadleOptions.copy(clockInfo = treadleOptions.clockInfo ++ Seq(parseClockInfo(x)))
-    }
+    .action( (x, a) => a :+ ClockInfoAnnotation(parseClockInfo(x)) )
     .text("clock-name[:period[:initial-offset]]")
 
   parser.opt[String]("fint-reset-name")
     .abbr("firn")
     .valueName("<string>")
-    .foreach { x =>
-      treadleOptions = treadleOptions.copy(resetName = x)
-    }
+    .action( (x, a) => a :+ ResetNameAnnotation(x) )
     .text("name of default reset")
+
+  parser.opt[Unit]("no-default-reset")
+    .abbr("findr")
+    .action( (_, a) => a :+ NoDefaultResetAnnotation )
+    .text("this prevents the tester from doing reset on it's own at startup")
+
+  parser.opt[Seq[String]]("symbols-to-watch")
+    .action( (x, a) => a ++ x.map(SymbolToWatchAnnotation(_)) )
+    .text("Symbols in the circuit to watch")
 }
 
 object Driver {
 
+  @deprecated("Use Driver.execute(optionsManager: HasTreadleSuite)", "1.0")
   def execute(firrtlInput: String, optionsManager: TreadleOptionsManager): Option[TreadleTester] = {
-    val tester = new TreadleTester(firrtlInput, optionsManager)
-    Some(tester)
+    val optionsManagerx = new ExecutionOptionsManager(
+      applicationName=optionsManager.applicationName,
+      args=Array.empty,
+      annotations=optionsManager.options :+ FirrtlSourceAnnotation(firrtlInput) ) with HasTreadleSuite
+    execute(optionsManagerx)
   }
 
-  def execute(args: Array[String], firrtlInput: String): Option[TreadleTester] = {
-    val optionsManager = new TreadleOptionsManager
+  def execute(optionsManager: HasTreadleSuite): Option[TreadleTester] =
+    Some(new TreadleTester(optionsManager))
 
-    if (optionsManager.parser.parse(args)) {
-      execute(firrtlInput, optionsManager)
-    } else {
-      None
-    }
+  def execute(args: Array[String], firrtlInput: String): Option[TreadleTester] = {
+    val opts = new ExecutionOptionsManager(
+      applicationName="engine",
+      args=args,
+      annotations=Seq(FirrtlSourceAnnotation(firrtlInput))) with HasTreadleSuite
+    execute(opts)
   }
 }
 
-class TreadleOptionsManager extends ExecutionOptionsManager("engine") with HasTreadleSuite
+class TreadleOptionsManager(args: Array[String]) extends ExecutionOptionsManager("engine", args) with HasTreadleSuite
 
-trait HasTreadleSuite extends ExecutionOptionsManager with HasFirrtlOptions with HasTreadleOptions {
+trait HasTreadleSuite extends ExecutionOptionsManager with HasFirrtlExecutionOptions with HasTreadleOptions {
   self : ExecutionOptionsManager =>
 }

--- a/src/main/scala/treadle/Driver.scala
+++ b/src/main/scala/treadle/Driver.scala
@@ -195,11 +195,10 @@ object Driver {
   def execute(optionsManager: HasTreadleSuite): Option[TreadleTester] =
     Some(new TreadleTester(optionsManager))
 
-  def execute(args: Array[String], firrtlInput: String): Option[TreadleTester] = {
+  def execute(args: Array[String]): Option[TreadleTester] = {
     val opts = new ExecutionOptionsManager(
-      applicationName="engine",
-      args=args,
-      annotations=Seq(FirrtlSourceAnnotation(firrtlInput))) with HasTreadleSuite
+      applicationName="treadle",
+      args=args) with HasTreadleSuite
     execute(opts)
   }
 }

--- a/src/main/scala/treadle/ExecutionEngine.scala
+++ b/src/main/scala/treadle/ExecutionEngine.scala
@@ -478,11 +478,19 @@ object ExecutionEngine {
     executionEngine
   }
 
+  @deprecated("Use ExecutionEngine(optionsManager: HasTreadleSuite)", "1.0.0")
   def apply(input: String, optionsManager: HasTreadleSuite): ExecutionEngine = {
     val optsx = new ExecutionOptionsManager(
       applicationName=optionsManager.applicationName,
       args=Array("--firrtl-source", input),
       annotations=optionsManager.options :+ DontCheckCombLoopsAnnotation) with HasTreadleSuite
     ExecutionEngine(optsx)
+  }
+
+  def apply(args: Array[String]): ExecutionEngine = {
+    val opts = new ExecutionOptionsManager(
+      applicationName="engine",
+      args=args) with HasTreadleSuite
+    ExecutionEngine(opts)
   }
 }

--- a/src/main/scala/treadle/ReplConfig.scala
+++ b/src/main/scala/treadle/ReplConfig.scala
@@ -2,72 +2,69 @@
 
 package treadle
 
-import firrtl.ExecutionOptionsManager
+import firrtl.{ExecutionOptionsManager, HasFirrtlExecutionOptions}
+import firrtl.annotations.{Annotation, SingleStringAnnotation, NoTargetAnnotation}
+
+sealed trait ReplOption { self: Annotation => }
+case class ScriptNameAnnotation(value: String) extends SingleStringAnnotation with ReplOption
+case object UseVcdScriptAnnotation extends NoTargetAnnotation with ReplOption
+case class VcdScriptOverrideAnnotation(value: String) extends SingleStringAnnotation with ReplOption
+case object RunScriptAtStartAnnotation extends NoTargetAnnotation with ReplOption
+case class OutputFormatAnnotation(value: String) extends SingleStringAnnotation with ReplOption
 
 case class ReplConfig(
-  firrtlSourceName : String = "",
-  scriptName       : String = "",
-  firrtlSource     : String = "",
+  scriptName       : Option[String] = None,
   useVcdScript     : Boolean = false,
-  vcdScriptOverride: String = "",
+  vcdScriptOverride: Option[String] = None,
   runScriptAtStart : Boolean = false,
   outputFormat     : String = "d"
 )
-        extends firrtl.ComposableOptions
 
 trait HasReplConfig {
-  self: ExecutionOptionsManager =>
+  self: ExecutionOptionsManager with HasFirrtlExecutionOptions =>
 
-  var replConfig = ReplConfig()
+  lazy val replConfig: ReplConfig = options
+    .collect{ case r: ReplOption => r }
+    .foldLeft(ReplConfig())( (r, x) =>
+      x match {
+        case ScriptNameAnnotation(n)        => r.copy(scriptName = Some(n))
+        case UseVcdScriptAnnotation         => r.copy(useVcdScript = true)
+        case VcdScriptOverrideAnnotation(s) => r.copy(vcdScriptOverride = Some(s))
+        case RunScriptAtStartAnnotation     => r.copy(runScriptAtStart = true)
+        case OutputFormatAnnotation(f)      => r.copy(outputFormat = f)
+      }
+    )
 
   parser.note("firrtl-repl")
-
-  parser.opt[String]("fr-firrtl-source")
-    .abbr("frfs")
-    .valueName("<firrtl-source-file>")
-    .foreach { x =>
-      replConfig = replConfig.copy(firrtlSourceName = x)
-    }
-    .text("firrtl file to load on startup, default is no file")
 
   parser.opt[String]("fr-script-file")
     .abbr("frsf")
     .valueName("<firrtl-script-file>")
-    .foreach { x =>
-      replConfig = replConfig.copy(scriptName = x)
-    }
+    .action( (x, a) => a :+ ScriptNameAnnotation(x) )
     .text("script file to load on startup, default is no file")
 
   parser.opt[Unit]("fr-use-vcd-script")
     .abbr("fruvs")
-    .foreach { _ =>
-      replConfig = replConfig.copy(useVcdScript = true)
-    }
+    .action( (_, a) => a :+ UseVcdScriptAnnotation )
     .text("load vcd file as script, default is false")
 
   parser.opt[String]("fr-vcd-script-override")
     .abbr("frvso")
     .valueName("<vcd-file>")
-    .foreach { x =>
-      replConfig = replConfig.copy(vcdScriptOverride = x, useVcdScript = true)
-    }
+    .action( (x, a) => a :+ VcdScriptOverrideAnnotation(x) )
     .text("load vcd file as script, default is false")
-
-  parser.opt[String]("fr-display-format")
-    .abbr("frdf")
-    .valueName("format")
-    .foreach { x =>
-      replConfig = replConfig.copy(outputFormat = x)
-    }
-    .text("how to display values d - decimal, x - hex, b - binary")
 
   parser.opt[Unit]("fr-run-script-on-startup")
     .abbr("frrsos")
     .valueName("<vcd-file>")
-    .foreach { _ =>
-      replConfig = replConfig.copy(runScriptAtStart = true)
-    }
+    .action( (_, a) => a :+ RunScriptAtStartAnnotation )
     .text("run script immediately on startup")
+
+  parser.opt[String]("fr-display-format")
+    .abbr("frdf")
+    .valueName("format")
+    .action( (x, a) => a :+ OutputFormatAnnotation(x) )
+    .text("how to display values d - decimal, x - hex, b - binary")
 
   def getVcdFileName: String = {
     self.getBuildFileName("vcd", replConfig.vcdScriptOverride)

--- a/src/main/scala/treadle/ToLoFirrtl.scala
+++ b/src/main/scala/treadle/ToLoFirrtl.scala
@@ -2,12 +2,12 @@
 
 package treadle
 
-import firrtl._
+import firrtl.{ExecutionOptionsManager, HasFirrtlExecutionOptions, LowFirrtlCompiler, CircuitState, ChirrtlForm}
 import firrtl.ir.Circuit
 
 object ToLoFirrtl {
   def lower(c: Circuit,
-            optionsManager: ExecutionOptionsManager with HasFirrtlOptions with HasTreadleOptions): Circuit = {
+            optionsManager: ExecutionOptionsManager with HasFirrtlExecutionOptions with HasTreadleOptions): Circuit = {
     val compiler = new LowFirrtlCompiler
 
     val annotations = optionsManager.firrtlOptions.annotations

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -330,7 +330,7 @@ class TreadleTester(optionsManager: HasTreadleSuite) {
 }
 
 object TreadleTester {
-  @deprecated("Use TreadleTester(optionsManager: ExecutionOptionsManager with HasTreadleSuite", "1.0.0")
+  @deprecated("Use TreadleTester(optionsManager: HasTreadleSuite", "1.0.0")
   def apply(input: String, optionsManager: TreadleOptionsManager): TreadleTester = {
     val optionsManagerx = new ExecutionOptionsManager(
       applicationName=optionsManager.applicationName,
@@ -340,9 +340,12 @@ object TreadleTester {
     new TreadleTester(optionsManagerx)
   }
 
-  def apply(optionsManager: HasTreadleSuite) = new TreadleTester(optionsManager)
+  def apply(optionsManager: HasTreadleSuite): TreadleTester = new TreadleTester(optionsManager)
 
-  def apply(input: String) = new TreadleTester(new ExecutionOptionsManager(
-                                                 applicationName="test",
-                                                 args=Array("--firrtl-source", input)) with HasTreadleSuite)
+  def apply(args: Array[String]): TreadleTester = {
+    val optionsManager = new ExecutionOptionsManager(
+      applicationName="Treadle Tester",
+      args=args) with HasTreadleSuite
+    new TreadleTester(optionsManager)
+  }
 }

--- a/src/main/scala/treadle/vcd/VCDConfig.scala
+++ b/src/main/scala/treadle/vcd/VCDConfig.scala
@@ -3,53 +3,72 @@
 package treadle.vcd
 
 import firrtl.ExecutionOptionsManager
+import firrtl.annotations.{Annotation, SingleStringAnnotation}
+
+sealed trait VcdOption { self: Annotation => }
+case class VcdSourceNameAnnotation(value: String) extends SingleStringAnnotation with VcdOption
+case class VcdTargetNameAnnotation(value: String) extends SingleStringAnnotation with VcdOption
+case class StartScopeAnnotation(value: String) extends SingleStringAnnotation with VcdOption
+case class RenameStartScopeAnnotation(value: String) extends SingleStringAnnotation with VcdOption
+case class VarPrefixAnnotation(value: String) extends SingleStringAnnotation with VcdOption
+case class NewVarPrefixAnnotation(value: String) extends SingleStringAnnotation with VcdOption
 
 case class VCDConfig(
-                     vcdSourceName:       String = "",
-                     vcdTargetName:       String = "",
-                     startScope:          String = "",
-                     renameStartScope:    String = "",
-                     varPrefix:           String = "",
-                     newVarPrefix:        String = "")
-  extends firrtl.ComposableOptions {
-}
+  vcdSourceName:       Option[String] = None,
+  vcdTargetName:       Option[String] = None,
+  startScope:          Option[String] = None,
+  renameStartScope:    Option[String] = None,
+  varPrefix:           Option[String] = None,
+  newVarPrefix:        Option[String] = None )
+
 
 trait HasVCDConfig {
   self: ExecutionOptionsManager =>
 
-  var vcdConfig = VCDConfig()
+  lazy val vcdConfig: VCDConfig = options
+    .collect{ case a: VcdOption => a }
+    .foldLeft(VCDConfig())( (v, x) =>
+      x match {
+        case VcdSourceNameAnnotation(n)    => v.copy(vcdSourceName = Some(n))
+        case VcdTargetNameAnnotation(n)    => v.copy(vcdTargetName = Some(n))
+        case StartScopeAnnotation(s)       => v.copy(startScope = Some(s))
+        case RenameStartScopeAnnotation(r) => v.copy(renameStartScope = Some(r))
+        case VarPrefixAnnotation(p)        => v.copy(varPrefix = Some(p))
+        case NewVarPrefixAnnotation(p)     => v.copy(newVarPrefix = Some(p))
+      }
+    )
 
   parser.note("vcd")
 
-  parser.opt[String]("start-scope")
-    .abbr("vss")
-    .foreach { x => vcdConfig = vcdConfig.copy(startScope = x)}
-    .text("starts saving information at specified scope")
-
-  parser.opt[String]("rename-start-scope")
-    .abbr("vrss")
-    .foreach { x => vcdConfig = vcdConfig.copy(renameStartScope = x)}
-    .text("rename startScope to this")
-
-  parser.opt[String]("<retain-vars-with-prefix>...")
-    .abbr("vrp")
-    .foreach { x => vcdConfig = vcdConfig.copy(varPrefix = x) }
-    .text("only vars that start with prefix will be kept")
-
-  parser.opt[String]("<new-var-prefix>...")
-    .abbr("vnvp")
-    .foreach { x => vcdConfig = vcdConfig.copy(newVarPrefix = x) }
-    .text("re-prefix vars with this string")
-
   parser.arg[String]("<input-vcd-file>...")
     .required()
-    .foreach { x => vcdConfig = vcdConfig.copy(vcdSourceName = x) }
+    .action( (x, a) => a :+ VcdSourceNameAnnotation(x) )
     .text("name of input vcd file")
 
   parser.arg[String]("<output-vcd-file>...")
     .optional()
-    .foreach { x => vcdConfig = vcdConfig.copy(vcdTargetName = x) }
+    .action( (x, a) => a :+ VcdTargetNameAnnotation(x) )
     .text("name of output vcd file (optional)")
+
+  parser.opt[String]("start-scope")
+    .abbr("vss")
+    .action( (x, a) => a :+ StartScopeAnnotation(x) )
+    .text("starts saving information at specified scope")
+
+  parser.opt[String]("rename-start-scope")
+    .abbr("vrss")
+    .action( (x, a) => a :+ RenameStartScopeAnnotation(x) )
+    .text("rename startScope to this")
+
+  parser.opt[String]("<retain-vars-with-prefix>...")
+    .abbr("vrp")
+    .action( (x, a) => a :+ VarPrefixAnnotation(x) )
+    .text("only vars that start with prefix will be kept")
+
+  parser.opt[String]("<new-var-prefix>...")
+    .abbr("vnvp")
+    .action( (x, a) => a :+ NewVarPrefixAnnotation(x) )
+    .text("re-prefix vars with this string")
 }
 
-class VCDOptionsManager extends ExecutionOptionsManager("vcd") with HasVCDConfig
+class VCDOptionsManager(args: Array[String]) extends ExecutionOptionsManager("vcd", args) with HasVCDConfig

--- a/src/test/scala/treadle/CarryOrChain3.scala
+++ b/src/test/scala/treadle/CarryOrChain3.scala
@@ -50,7 +50,7 @@ class CarryOrChain3 extends FreeSpec with Matchers {
       bin.toList.map( "01".indexOf(_)).map( BigInt(_)).reverse.toArray
     }
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
 
     val lst = List( (v("001"),v("111")))
     for ( (a,co) <- lst) {

--- a/src/test/scala/treadle/CarryOrChain3.scala
+++ b/src/test/scala/treadle/CarryOrChain3.scala
@@ -50,7 +50,7 @@ class CarryOrChain3 extends FreeSpec with Matchers {
       bin.toList.map( "01".indexOf(_)).map( BigInt(_)).reverse.toArray
     }
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     val lst = List( (v("001"),v("111")))
     for ( (a,co) <- lst) {

--- a/src/test/scala/treadle/CarryOrChain6.scala
+++ b/src/test/scala/treadle/CarryOrChain6.scala
@@ -76,7 +76,7 @@ class CarryOrChain6 extends FreeSpec with Matchers {
       bin.toList.map( "01".indexOf(_)).map( BigInt(_)).reverse.toArray
     }
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
 
     val lst = List( (v("000001"),v("111111")))
     for ( (a,co) <- lst) {

--- a/src/test/scala/treadle/CarryOrChain6.scala
+++ b/src/test/scala/treadle/CarryOrChain6.scala
@@ -76,7 +76,7 @@ class CarryOrChain6 extends FreeSpec with Matchers {
       bin.toList.map( "01".indexOf(_)).map( BigInt(_)).reverse.toArray
     }
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     val lst = List( (v("000001"),v("111111")))
     for ( (a,co) <- lst) {

--- a/src/test/scala/treadle/ClockSpec.scala
+++ b/src/test/scala/treadle/ClockSpec.scala
@@ -2,8 +2,8 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class ClockSpec extends FreeSpec with Matchers {
@@ -41,15 +41,13 @@ class ClockSpec extends FreeSpec with Matchers {
         |      stop(clock, UInt(1), 0) ; Done!
         |
       """.stripMargin
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        vcdShowUnderscored = true,
-        writeVCD = true
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-vcd-show-underscored-vars",
+            "--fint-write-vcd",
+            "--firrtl-source", input)
+    ) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     intercept[StopException] {
       tester.step(100)

--- a/src/test/scala/treadle/DeepExecutionSpec.scala
+++ b/src/test/scala/treadle/DeepExecutionSpec.scala
@@ -9,7 +9,7 @@ class DeepExecutionSpec extends FreeSpec with Matchers {
   "DeepExecutionSpec should pass a basic test" in {
     val stream = getClass.getResourceAsStream("/DeepExecution.fir")
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.step(100)
     tester.report()

--- a/src/test/scala/treadle/DeepExecutionSpec.scala
+++ b/src/test/scala/treadle/DeepExecutionSpec.scala
@@ -4,13 +4,12 @@ package treadle
 
 import org.scalatest.{FreeSpec, Matchers}
 
-
 // scalastyle:off magic.number
 class DeepExecutionSpec extends FreeSpec with Matchers {
   "DeepExecutionSpec should pass a basic test" in {
     val stream = getClass.getResourceAsStream("/DeepExecution.fir")
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
 
     tester.step(100)
     tester.report()

--- a/src/test/scala/treadle/DriverSpec.scala
+++ b/src/test/scala/treadle/DriverSpec.scala
@@ -15,8 +15,9 @@ class DriverSpec extends FreeSpec with Matchers {
           |    output y : UInt<1>
           |    y <= x
         """.stripMargin
-      //      val engine = Driver.execute(Array.empty[String], input)
-      val engine = Driver.execute(Array("--fint-verbose"), input)
+
+      val engine = Driver.execute(Array("--fint-verbose",
+                                        "--firrtl-source", input))
 
       engine should not be empty
 

--- a/src/test/scala/treadle/DynamicMemorySearch.scala
+++ b/src/test/scala/treadle/DynamicMemorySearch.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -53,7 +54,11 @@ class DynamicMemorySearch extends FlatSpec with Matchers {
     val n = 8
     val w = 4
 
-    new TreadleTester(input) {
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", input)) with HasTreadleSuite
+
+    new TreadleTester(optionsManager) {
 //      engine.setVerbose(true)
 //      engine.sourceState.memories("list").setVerbose()
 

--- a/src/test/scala/treadle/ExpressionRenderSpec.scala
+++ b/src/test/scala/treadle/ExpressionRenderSpec.scala
@@ -32,17 +32,12 @@ class ExpressionRenderSpec extends FreeSpec with Matchers {
         |    out <= node0
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--fint-vcd-show-underscored-vars",
-            "--fint-verbose",
-            "--show-firrtl-at-load",
-            "--fint-rollback-buffers", "0",
-            "--firrtl-source", input)
-    ) with HasTreadleSuite
-
-    val t = new TreadleTester(optionsManager)
+    val t = TreadleTester(Array("--fint-write-vcd",
+                                "--fint-vcd-show-underscored-vars",
+                                "--fint-verbose",
+                                "--show-firrtl-at-load",
+                                "--fint-rollback-buffers", "0",
+                                "--firrtl-source", input))
     t.poke("in0", 10)
     t.poke("in1", 11)
     t.poke("in2", 12)

--- a/src/test/scala/treadle/ExpressionRenderSpec.scala
+++ b/src/test/scala/treadle/ExpressionRenderSpec.scala
@@ -2,8 +2,8 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class ExpressionRenderSpec extends FreeSpec with Matchers {
@@ -32,18 +32,17 @@ class ExpressionRenderSpec extends FreeSpec with Matchers {
         |    out <= node0
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = true,
-        rollbackBuffers = 0,
-        symbolsToWatch = Seq()
-      )
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--fint-vcd-show-underscored-vars",
+            "--fint-verbose",
+            "--show-firrtl-at-load",
+            "--fint-rollback-buffers", "0",
+            "--firrtl-source", input)
+    ) with HasTreadleSuite
 
-    val t = new TreadleTester(input, optionsManager)
+    val t = new TreadleTester(optionsManager)
     t.poke("in0", 10)
     t.poke("in1", 11)
     t.poke("in2", 12)

--- a/src/test/scala/treadle/FailSpec.scala
+++ b/src/test/scala/treadle/FailSpec.scala
@@ -16,7 +16,7 @@ class FailSpec extends FlatSpec with Matchers {
         |    output c : Fixed
         |    c <= mul(a, b)""".stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.fail(3)
     tester.report()

--- a/src/test/scala/treadle/FailSpec.scala
+++ b/src/test/scala/treadle/FailSpec.scala
@@ -16,7 +16,7 @@ class FailSpec extends FlatSpec with Matchers {
         |    output c : Fixed
         |    c <= mul(a, b)""".stripMargin
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
 
     tester.fail(3)
     tester.report()

--- a/src/test/scala/treadle/FixedPointDivide.scala
+++ b/src/test/scala/treadle/FixedPointDivide.scala
@@ -24,7 +24,7 @@ class FixedPointDivide extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("io_in", 256)
     tester.expect("io_out", 64)
@@ -56,7 +56,7 @@ class SignedAdder extends FreeSpec with Matchers {
           |    io_out <= _T_7
         """.stripMargin
 
-        val tester = TreadleTester(input)
+        val tester = TreadleTester(Array("--firrtl-source", input))
 
         for {
           i <- BigIntTestValuesGenerator(extremaOfSIntOfWidth(bitWidth))
@@ -157,7 +157,7 @@ class DynamicShiftRight extends FreeSpec with Matchers {
           |
         """.stripMargin
 
-        val tester = TreadleTester(input)
+        val tester = TreadleTester(Array("--firrtl-source", input))
 
         val mask = BigInt("1" * bitWidth, 2)
 

--- a/src/test/scala/treadle/FixedPointDivide.scala
+++ b/src/test/scala/treadle/FixedPointDivide.scala
@@ -24,7 +24,7 @@ class FixedPointDivide extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
 
     tester.poke("io_in", 256)
     tester.expect("io_out", 64)
@@ -56,7 +56,7 @@ class SignedAdder extends FreeSpec with Matchers {
           |    io_out <= _T_7
         """.stripMargin
 
-        val tester = new TreadleTester(input)
+        val tester = TreadleTester(input)
 
         for {
           i <- BigIntTestValuesGenerator(extremaOfSIntOfWidth(bitWidth))
@@ -157,9 +157,7 @@ class DynamicShiftRight extends FreeSpec with Matchers {
           |
         """.stripMargin
 
-        val tester = new
-
-        TreadleTester(input)
+        val tester = TreadleTester(input)
 
         val mask = BigInt("1" * bitWidth, 2)
 

--- a/src/test/scala/treadle/GCDTester.scala
+++ b/src/test/scala/treadle/GCDTester.scala
@@ -58,18 +58,13 @@ class GCDTester extends FlatSpec with Matchers {
     """
         .stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-rollback-buffers", "0",
-            "--firrtl-source", gcdFirrtl)
-    ) with HasTreadleSuite
-
     val values =
       for {x <- 1 to 1000
            y <- 1 to 100
       } yield (x, y, computeGcd(x, y)._1)
 
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-rollback-buffers", "0",
+                                     "--firrtl-source", gcdFirrtl))
 
     val startTime = System.nanoTime()
     // engine.setVerbose()
@@ -150,18 +145,13 @@ class GCDTester extends FlatSpec with Matchers {
     """
         .stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-rollback-buffers", "0",
-            "--firrtl-source", gcdFirrtl)
-    ) with HasTreadleSuite
-
     val values =
       for {x <- 10 to 1000
            y <- 1 to 100
       } yield (x, y, computeGcd(x, y)._1)
 
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-rollback-buffers", "0",
+                                     "--firrtl-source", gcdFirrtl))
 
     val startTime = System.nanoTime()
     tester.poke("clock", 1)

--- a/src/test/scala/treadle/GCDTester.scala
+++ b/src/test/scala/treadle/GCDTester.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FlatSpec, Matchers}
 
 // scalastyle:off magic.number
@@ -57,17 +58,18 @@ class GCDTester extends FlatSpec with Matchers {
     """
         .stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-rollback-buffers", "0",
+            "--firrtl-source", gcdFirrtl)
+    ) with HasTreadleSuite
 
     val values =
       for {x <- 1 to 1000
            y <- 1 to 100
       } yield (x, y, computeGcd(x, y)._1)
 
-    val tester = new TreadleTester(gcdFirrtl, manager)
+    val tester = new TreadleTester(optionsManager)
 
     val startTime = System.nanoTime()
     // engine.setVerbose()
@@ -148,20 +150,18 @@ class GCDTester extends FlatSpec with Matchers {
     """
         .stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        showFirrtlAtLoad = false,
-        setVerbose = false,
-        rollbackBuffers = 0
-      )
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-rollback-buffers", "0",
+            "--firrtl-source", gcdFirrtl)
+    ) with HasTreadleSuite
 
     val values =
       for {x <- 10 to 1000
            y <- 1 to 100
       } yield (x, y, computeGcd(x, y)._1)
 
-    val tester = new TreadleTester(gcdFirrtl, manager)
+    val tester = new TreadleTester(optionsManager)
 
     val startTime = System.nanoTime()
     tester.poke("clock", 1)

--- a/src/test/scala/treadle/GetIntBreakdownSpec.scala
+++ b/src/test/scala/treadle/GetIntBreakdownSpec.scala
@@ -35,12 +35,8 @@ class GetIntBreakdownSpec extends FreeSpec with Matchers {
 
 //    println(firrtlString.split("\n").zipWithIndex.map { case (l,n) => f"$n%5d $l"}.mkString("\n"))
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-rollback-buffers", "0",
-            "--firrtl-source", input)) with HasTreadleSuite
-
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-rollback-buffers", "0",
+                                     "--firrtl-source", input))
 
     for(i <- 0 to 1000) {
       tester.poke("io_in", 4)

--- a/src/test/scala/treadle/GetIntBreakdownSpec.scala
+++ b/src/test/scala/treadle/GetIntBreakdownSpec.scala
@@ -2,8 +2,8 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class GetIntBreakdownSpec extends FreeSpec with Matchers {
@@ -35,15 +35,12 @@ class GetIntBreakdownSpec extends FreeSpec with Matchers {
 
 //    println(firrtlString.split("\n").zipWithIndex.map { case (l,n) => f"$n%5d $l"}.mkString("\n"))
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        showFirrtlAtLoad = false,
-        //        setVerbose = true,
-        rollbackBuffers = 0
-      )
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-rollback-buffers", "0",
+            "--firrtl-source", input)) with HasTreadleSuite
 
-    val tester = new TreadleTester(firrtlString, manager)
+    val tester = new TreadleTester(optionsManager)
 
     for(i <- 0 to 1000) {
       tester.poke("io_in", 4)

--- a/src/test/scala/treadle/LifeCellSpec.scala
+++ b/src/test/scala/treadle/LifeCellSpec.scala
@@ -1,7 +1,7 @@
 // See LICENSE for license details.
 package treadle
 
-import firrtl.CommonOptions
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FlatSpec, Matchers}
 
 class LifeCellSpec extends FlatSpec with Matchers {
@@ -47,12 +47,13 @@ class LifeCellSpec extends FlatSpec with Matchers {
         |    io.is_alive <= T_36
         |      """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(writeVCD = true)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--firrtl-source", input,
+            "--target-dir", "test_run_dir")) with HasTreadleSuite
 
-    new TreadleTester(input, optionsManager) {
+    new TreadleTester(optionsManager) {
       // setVerbose()
       step()
 

--- a/src/test/scala/treadle/MemoryUsageSpec.scala
+++ b/src/test/scala/treadle/MemoryUsageSpec.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -67,10 +68,11 @@ class MemoryUsageSpec extends FlatSpec with Matchers {
         |    waddr <= bits(GEN_18, 3, 0)
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(showFirrtlAtLoad = false, setVerbose = false)
-    }
-    val tester = new TreadleTester(chirrtlMemInput, optionsManager) {
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", chirrtlMemInput)) with HasTreadleSuite
+
+    val tester = new TreadleTester(optionsManager) {
       poke("reset", 1)
       step()
       poke("reset", 0)
@@ -116,7 +118,11 @@ class MemoryUsageSpec extends FlatSpec with Matchers {
         |    c <= a
       """.stripMargin
 
-    val tester = new TreadleTester(input) {
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", input)) with HasTreadleSuite
+
+    val tester = new TreadleTester(optionsManager) {
       poke("a", 1)
       poke("b", 0)
       poke("select", 0)
@@ -166,7 +172,11 @@ class MemoryUsageSpec extends FlatSpec with Matchers {
         |    ram.RW_0.wmask <= UInt<1>("h1")
       """.stripMargin
 
-    val tester = new TreadleTester(input) {
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", input)) with HasTreadleSuite
+
+    val tester = new TreadleTester(optionsManager) {
       // setVerbose(true)
 
       poke("do_write", 1)
@@ -241,10 +251,11 @@ class MemoryUsageSpec extends FlatSpec with Matchers {
         |    ram.RW_0.wmask <= UInt<1>("h1")
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(showFirrtlAtLoad = false, setVerbose = false)
-    }
-    val tester = new TreadleTester(input, optionsManager) {
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", input)) with HasTreadleSuite
+
+    val tester = new TreadleTester(optionsManager) {
       // setVerbose(true)
 
       poke("outer_write_en", 1)

--- a/src/test/scala/treadle/ModuleInLineSpec.scala
+++ b/src/test/scala/treadle/ModuleInLineSpec.scala
@@ -11,7 +11,7 @@ class ModuleInLineSpec extends FlatSpec with Matchers {
     val stream = getClass.getResourceAsStream("/three_deep.fir")
     val input = io.Source.fromInputStream(stream).mkString
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.engine.symbolTable.outputPortsNames.size should be > 0
   }

--- a/src/test/scala/treadle/ModuleInLineSpec.scala
+++ b/src/test/scala/treadle/ModuleInLineSpec.scala
@@ -11,7 +11,7 @@ class ModuleInLineSpec extends FlatSpec with Matchers {
     val stream = getClass.getResourceAsStream("/three_deep.fir")
     val input = io.Source.fromInputStream(stream).mkString
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
 
     tester.engine.symbolTable.outputPortsNames.size should be > 0
   }

--- a/src/test/scala/treadle/MultiClockMemorySpec.scala
+++ b/src/test/scala/treadle/MultiClockMemorySpec.scala
@@ -2,8 +2,8 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class MultiClockMemorySpec extends FreeSpec with Matchers {
@@ -103,18 +103,12 @@ class MultiClockMemorySpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = true,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 4,
-        symbolsToWatch = Seq()
-      )
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--firrtl-source", input)) with HasTreadleSuite
 
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = new TreadleTester(optionsManager)
 
     tester.step(100)
     tester.report()

--- a/src/test/scala/treadle/OutputAsSourceSpec.scala
+++ b/src/test/scala/treadle/OutputAsSourceSpec.scala
@@ -20,7 +20,7 @@ class OutputAsSourceSpec extends FreeSpec with Matchers {
         |    out2 <= T_1
       """.stripMargin
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
     // tester.setVerbose(true)
 
     tester.poke("in1", 1)

--- a/src/test/scala/treadle/OutputAsSourceSpec.scala
+++ b/src/test/scala/treadle/OutputAsSourceSpec.scala
@@ -20,7 +20,7 @@ class OutputAsSourceSpec extends FreeSpec with Matchers {
         |    out2 <= T_1
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
     // tester.setVerbose(true)
 
     tester.poke("in1", 1)

--- a/src/test/scala/treadle/Performance.scala
+++ b/src/test/scala/treadle/Performance.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
 
 class Performance extends FreeSpec with Matchers {
@@ -30,12 +31,12 @@ class Performance extends FreeSpec with Matchers {
     """
               .stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-rollback-buffers", "0",
+            "--firrtl-source", junkFirrtl)) with HasTreadleSuite
 
-    val tester = new TreadleTester(junkFirrtl, manager)
+    val tester = new TreadleTester(optionsManager)
 
     val startTime = System.nanoTime()
 

--- a/src/test/scala/treadle/PrintStopSpec.scala
+++ b/src/test/scala/treadle/PrintStopSpec.scala
@@ -155,7 +155,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
         """.stripMargin
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
     tester.poke("enable", 0)
     tester.poke("in1", 1)
     println("before peek")

--- a/src/test/scala/treadle/PrintStopSpec.scala
+++ b/src/test/scala/treadle/PrintStopSpec.scala
@@ -18,7 +18,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     for (cycle_number <- 0 to 10) {
       tester.step(2)
@@ -36,7 +36,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     intercept[StopException] {
       tester.step(2)
@@ -55,7 +55,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     intercept[StopException] {
       tester.step(2)
@@ -79,7 +79,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
           |
       """.stripMargin
 
-      val tester = TreadleTester(input)
+      val tester = TreadleTester(Array("--firrtl-source", input))
 
       tester.step(2)
     }
@@ -101,7 +101,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
           |
       """.stripMargin
 
-      val tester = TreadleTester(input)
+      val tester = TreadleTester(Array("--firrtl-source", input))
 
       tester.step(2)
     }
@@ -125,7 +125,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
           |
         """.stripMargin
 
-      val tester = TreadleTester(input)
+      val tester = TreadleTester(Array("--firrtl-source", input))
 
       tester.step(2)
     }
@@ -155,7 +155,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
         """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
     tester.poke("enable", 0)
     tester.poke("in1", 1)
     println("before peek")

--- a/src/test/scala/treadle/RegOfVecSpec.scala
+++ b/src/test/scala/treadle/RegOfVecSpec.scala
@@ -90,7 +90,7 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("reset", 1)
     tester.step(3)
@@ -129,14 +129,10 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         |    stop(clock, and(and(and(UInt<1>("h1"), done), _T_18), UInt<1>("h1")), 0) @[Reg.scala 61:9]
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--fint-vcd-show-underscored-vars",
-            "--show-firrtl-at-load",
-            "--firrtl-source", input)) with HasTreadleSuite
-
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-write-vcd",
+                                     "--fint-vcd-show-underscored-vars",
+                                     "--show-firrtl-at-load",
+                                     "--firrtl-source", input))
 
     def show(): Unit = {
       tester.step()

--- a/src/test/scala/treadle/RegOfVecSpec.scala
+++ b/src/test/scala/treadle/RegOfVecSpec.scala
@@ -2,8 +2,8 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class RegOfVecSpec extends FreeSpec with Matchers {
@@ -90,15 +90,7 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = TreadleTester(input)
 
     tester.poke("reset", 1)
     tester.step(3)
@@ -137,16 +129,14 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         |    stop(clock, and(and(and(UInt<1>("h1"), done), _T_18), UInt<1>("h1")), 0) @[Reg.scala 61:9]
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = true,
-        vcdShowUnderscored = true,
-        setVerbose = false,
-        showFirrtlAtLoad = true
-      )
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--fint-vcd-show-underscored-vars",
+            "--show-firrtl-at-load",
+            "--firrtl-source", input)) with HasTreadleSuite
 
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = new TreadleTester(optionsManager)
 
     def show(): Unit = {
       tester.step()

--- a/src/test/scala/treadle/RegisterCycleTest.scala
+++ b/src/test/scala/treadle/RegisterCycleTest.scala
@@ -39,7 +39,7 @@ class RegisterCycleTest extends FreeSpec with Matchers {
       for(i <- 0 to 10) {
         println(s"experiment $i")
         scala.util.Random.setSeed(i.toLong)
-        val tester = TreadleTester(input)
+        val tester = TreadleTester(Array("--firrtl-source", input))
 //        tester.setVerbose(true)
 
         tester.poke("reset", 1)
@@ -83,7 +83,7 @@ class RegisterCycleTest extends FreeSpec with Matchers {
         """.stripMargin
 
 
-      val tester = TreadleTester(input)
+      val tester = TreadleTester(Array("--firrtl-source", input))
       // tester.setVerbose()
 
       tester.poke("io_In", 1)

--- a/src/test/scala/treadle/RegisterCycleTest.scala
+++ b/src/test/scala/treadle/RegisterCycleTest.scala
@@ -39,7 +39,7 @@ class RegisterCycleTest extends FreeSpec with Matchers {
       for(i <- 0 to 10) {
         println(s"experiment $i")
         scala.util.Random.setSeed(i.toLong)
-        val tester = new TreadleTester(input)
+        val tester = TreadleTester(input)
 //        tester.setVerbose(true)
 
         tester.poke("reset", 1)
@@ -83,7 +83,7 @@ class RegisterCycleTest extends FreeSpec with Matchers {
         """.stripMargin
 
 
-      val tester = new TreadleTester(input)
+      val tester = TreadleTester(input)
       // tester.setVerbose()
 
       tester.poke("io_In", 1)

--- a/src/test/scala/treadle/RegisterSpec.scala
+++ b/src/test/scala/treadle/RegisterSpec.scala
@@ -22,12 +22,8 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--no-default-reset",
-            "--firrtl-source", input)) with HasTreadleSuite
-
-    val tester = TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--no-default-reset",
+                                     "--firrtl-source", input))
 
     tester.poke("reset1", 1)
     tester.step()
@@ -69,12 +65,9 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-verbose",
-            "--no-default-reset",
-            "--firrtl-source", input)) with HasTreadleSuite
-    val tester = TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-verbose",
+                                     "--no-default-reset",
+                                     "--firrtl-source", input))
 
     tester.poke("reset1", 1)
     tester.poke("reset2", 0)
@@ -141,12 +134,8 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--firrtl-source", input)) with HasTreadleSuite
-
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-write-vcd",
+                                     "--firrtl-source", input))
     tester.poke("reset", 1)
     tester.step()
     tester.poke("reset", 0)
@@ -170,12 +159,9 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--no-default-reset",
-            "--fint-write-vcd",
-            "--firrtl-source", input)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--no-default-reset",
+                                     "--fint-write-vcd",
+                                     "--firrtl-source", input))
 
     tester.poke("reset1", 1)
     tester.step()
@@ -232,12 +218,8 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--no-default-reset",
-            "--firrtl-source", input)) with HasTreadleSuite
-
-    val tester = TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--no-default-reset",
+                                     "--firrtl-source", input))
 
 
     tester.poke("in", 7)
@@ -297,12 +279,9 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--no-default-reset",
-            "--fint-rollback-buffers", "15",
-            "--firrtl-source", input)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--no-default-reset",
+                                     "--fint-rollback-buffers", "15",
+                                     "--firrtl-source", input))
 
     tester.poke("io_in", 77)
     tester.poke("io_en", 0)

--- a/src/test/scala/treadle/RegisterSpec.scala
+++ b/src/test/scala/treadle/RegisterSpec.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FlatSpec, Matchers}
 
 // scalastyle:off magic.number
@@ -21,13 +22,12 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        noDefaultReset = true
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--no-default-reset",
+            "--firrtl-source", input)) with HasTreadleSuite
+
+    val tester = TreadleTester(optionsManager)
 
     tester.poke("reset1", 1)
     tester.step()
@@ -69,13 +69,12 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = true,
-        noDefaultReset = true
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-verbose",
+            "--no-default-reset",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val tester = TreadleTester(optionsManager)
 
     tester.poke("reset1", 1)
     tester.poke("reset2", 0)
@@ -142,10 +141,12 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false, writeVCD = true)
-    }
-    val tester = new TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--firrtl-source", input)) with HasTreadleSuite
+
+    val tester = new TreadleTester(optionsManager)
     tester.poke("reset", 1)
     tester.step()
     tester.poke("reset", 0)
@@ -169,13 +170,12 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        noDefaultReset = true,
-        writeVCD = true)
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--no-default-reset",
+            "--fint-write-vcd",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     tester.poke("reset1", 1)
     tester.step()
@@ -232,13 +232,12 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        noDefaultReset = true
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--no-default-reset",
+            "--firrtl-source", input)) with HasTreadleSuite
+
+    val tester = TreadleTester(optionsManager)
 
 
     tester.poke("in", 7)
@@ -298,14 +297,12 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        showFirrtlAtLoad = false,
-        setVerbose = false,
-        noDefaultReset = true,
-        rollbackBuffers = 15)
-    }
-    val tester = new TreadleTester(input, manager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--no-default-reset",
+            "--fint-rollback-buffers", "15",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     tester.poke("io_in", 77)
     tester.poke("io_en", 0)

--- a/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
+++ b/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
 
 class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
@@ -10,18 +11,12 @@ class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
     val stream = getClass.getResourceAsStream("/core-simple.lo.fir")
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = true,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 0,
-        symbolsToWatch = Seq() // Seq("dut.io_host_tohost", "dut.dpath.csr.mtohost")
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--fint-rollback-buffers", "0",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     intercept[StopException] {
       tester.step(300)
@@ -30,4 +25,3 @@ class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
     tester.engine.lastStopResult should be (Some(0))
   }
 }
-

--- a/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
+++ b/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
@@ -11,12 +11,9 @@ class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
     val stream = getClass.getResourceAsStream("/core-simple.lo.fir")
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--fint-rollback-buffers", "0",
-            "--firrtl-source", input)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-write-vcd",
+                                     "--fint-rollback-buffers", "0",
+                                     "--firrtl-source", input))
 
     intercept[StopException] {
       tester.step(300)

--- a/src/test/scala/treadle/ShiftRegisterSpec.scala
+++ b/src/test/scala/treadle/ShiftRegisterSpec.scala
@@ -2,8 +2,8 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class ShiftRegisterSpec extends FreeSpec with Matchers {
@@ -34,18 +34,11 @@ class ShiftRegisterSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = true,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 4,
-        symbolsToWatch = Seq() // Seq("sr", "sr/in")
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     intercept[StopException] {
       tester.step(8)

--- a/src/test/scala/treadle/ShiftRegisterSpec.scala
+++ b/src/test/scala/treadle/ShiftRegisterSpec.scala
@@ -34,11 +34,8 @@ class ShiftRegisterSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--firrtl-source", input)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--fint-write-vcd",
+                                     "--firrtl-source", input))
 
     intercept[StopException] {
       tester.step(8)

--- a/src/test/scala/treadle/SimpleVendingMachineSpec.scala
+++ b/src/test/scala/treadle/SimpleVendingMachineSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
 
 //scalastyle:off magic.number
@@ -149,18 +150,13 @@ class SimpleVendingMachineSpec extends FreeSpec with Matchers{
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = true,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 0,
-        symbolsToWatch = Seq("dut.state", "dut.state/in")
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--fint-rollback-buffers", "0",
+            "--symbols-to-watch", "dut.state,dut.state/in",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     intercept[StopException] {
       tester.step(80)

--- a/src/test/scala/treadle/StackSpec.scala
+++ b/src/test/scala/treadle/StackSpec.scala
@@ -4,7 +4,6 @@ package treadle
 
 import org.scalatest.{FreeSpec, Matchers}
 
-
 // scalastyle:off magic.number
 class StackSpec extends FreeSpec with Matchers {
   "StackSpec should pass a basic test" in {
@@ -80,7 +79,7 @@ class StackSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
 
     tester.poke("io_en", 1)
     tester.poke("io_push", 1)

--- a/src/test/scala/treadle/StackSpec.scala
+++ b/src/test/scala/treadle/StackSpec.scala
@@ -79,7 +79,7 @@ class StackSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("io_en", 1)
     tester.poke("io_push", 1)

--- a/src/test/scala/treadle/StopBehaviorSpec.scala
+++ b/src/test/scala/treadle/StopBehaviorSpec.scala
@@ -46,7 +46,7 @@ class StopBehaviorSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "Stop should abort engine immediately" in {
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("reset", 0)
     tester.poke("io_wrData", (0 << 24) + (255 << 16))

--- a/src/test/scala/treadle/StopBehaviorSpec.scala
+++ b/src/test/scala/treadle/StopBehaviorSpec.scala
@@ -2,7 +2,6 @@
 
 package treadle
 
-import firrtl.CommonOptions
 import org.scalatest.{FreeSpec, Matchers}
 
 class StopBehaviorSpec extends FreeSpec with Matchers {
@@ -47,10 +46,7 @@ class StopBehaviorSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "Stop should abort engine immediately" in {
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-    }
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = TreadleTester(input)
 
     tester.poke("reset", 0)
     tester.poke("io_wrData", (0 << 24) + (255 << 16))

--- a/src/test/scala/treadle/VecSpec.scala
+++ b/src/test/scala/treadle/VecSpec.scala
@@ -29,7 +29,7 @@ class VecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 //
 //    tester.poke("reset", 1)
 //    tester.step()
@@ -104,7 +104,7 @@ class VecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("reset", 1)
     tester.step()

--- a/src/test/scala/treadle/VecSpec.scala
+++ b/src/test/scala/treadle/VecSpec.scala
@@ -2,9 +2,7 @@
 
 package treadle
 
-import firrtl.CommonOptions
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class VecSpec extends FreeSpec with Matchers {
@@ -31,15 +29,7 @@ class VecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = TreadleTester(input)
 //
 //    tester.poke("reset", 1)
 //    tester.step()
@@ -114,14 +104,7 @@ class VecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        setVerbose = false
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = TreadleTester(input)
 
     tester.poke("reset", 1)
     tester.step()

--- a/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle.blackboxes
 
+import firrtl.ExecutionOptionsManager
 import firrtl.ir.Type
 import treadle._
 import org.scalatest.{FreeSpec, Matchers}
@@ -107,15 +108,13 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
 
     "each output should hold a different values" in {
 
-      val factory = new FanOutAdderFactory
+      val optionsManager = new ExecutionOptionsManager(
+        "test",
+        Array("--fint-random-seed", "0",
+              "--blackbox-factory", "treadle.blackboxes.FanOutAdderFactory",
+              "--firrtl-source", adderInput)) with HasTreadleSuite
 
-      val optionsManager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          setVerbose = false,
-          blackBoxFactories = Seq(factory),
-          randomSeed = 0L)
-      }
-      val tester = new TreadleTester(adderInput, optionsManager)
+      val tester = new TreadleTester(optionsManager)
 
       for(i <- 0 until 10) {
         tester.poke("in", i)
@@ -153,13 +152,13 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
 
       val factory = new BlackBoxCounterFactory
 
-      val optionsManager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          setVerbose = false,
-          blackBoxFactories = Seq(factory),
-          randomSeed = 0L)
-      }
-      val tester = new TreadleTester(input, optionsManager)
+      val optionsManager = new ExecutionOptionsManager(
+        "test",
+        Array("--fint-random-seed", "0",
+              "--blackbox-factory", "treadle.blackboxes.BlackBoxCounterFactory",
+              "--firrtl-source", input)) with HasTreadleSuite
+
+      val tester = new TreadleTester(optionsManager)
 
       tester.poke("clear", 1)
       tester.step()

--- a/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
@@ -108,13 +108,9 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
 
     "each output should hold a different values" in {
 
-      val optionsManager = new ExecutionOptionsManager(
-        "test",
-        Array("--fint-random-seed", "0",
-              "--blackbox-factory", "treadle.blackboxes.FanOutAdderFactory",
-              "--firrtl-source", adderInput)) with HasTreadleSuite
-
-      val tester = new TreadleTester(optionsManager)
+      val tester = TreadleTester(Array("--fint-random-seed", "0",
+                                       "--blackbox-factory", "treadle.blackboxes.FanOutAdderFactory",
+                                       "--firrtl-source", adderInput))
 
       for(i <- 0 until 10) {
         tester.poke("in", i)
@@ -152,13 +148,9 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
 
       val factory = new BlackBoxCounterFactory
 
-      val optionsManager = new ExecutionOptionsManager(
-        "test",
-        Array("--fint-random-seed", "0",
-              "--blackbox-factory", "treadle.blackboxes.BlackBoxCounterFactory",
-              "--firrtl-source", input)) with HasTreadleSuite
-
-      val tester = new TreadleTester(optionsManager)
+      val tester = TreadleTester(Array("--fint-random-seed", "0",
+                                       "--blackbox-factory", "treadle.blackboxes.BlackBoxCounterFactory",
+                                       "--firrtl-source", input))
 
       tester.poke("clear", 1)
       tester.step()

--- a/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
@@ -34,12 +34,9 @@ class BlackBoxWithState extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--symbols-to-watch", "io_data",
-            "--blackbox-factory", "treadle.blackboxes.AccumBlackBoxFactory",
-            "--firrtl-source", input)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--symbols-to-watch", "io_data",
+                                     "--blackbox-factory", "treadle.blackboxes.AccumBlackBoxFactory",
+                                     "--firrtl-source", input))
 
     val initialValue = tester.peek("io_data")
     println(s"Initial value is $initialValue")

--- a/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
@@ -2,11 +2,11 @@
 
 package treadle.blackboxes
 
+import firrtl.ExecutionOptionsManager
 import firrtl.ir.Type
-import treadle.{BlackBoxFactory, BlackBoxImplementation, TreadleOptionsManager, TreadleTester}
+import treadle.{BlackBoxFactory, BlackBoxImplementation, TreadleOptionsManager, TreadleTester, HasTreadleSuite}
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.{PositiveEdge, Transition}
-
 
 // scalastyle:off magic.number
 class BlackBoxWithState extends FreeSpec with Matchers {
@@ -34,14 +34,12 @@ class BlackBoxWithState extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        symbolsToWatch = Seq("io_data"),
-        blackBoxFactories = Seq(new AccumBlackBoxFactory)
-      )
-    }
-    val tester = new TreadleTester(input, manager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--symbols-to-watch", "io_data",
+            "--blackbox-factory", "treadle.blackboxes.AccumBlackBoxFactory",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     val initialValue = tester.peek("io_data")
     println(s"Initial value is $initialValue")

--- a/src/test/scala/treadle/chronometry/ClockMadness.scala
+++ b/src/test/scala/treadle/chronometry/ClockMadness.scala
@@ -39,7 +39,7 @@ class ClockMadnessSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "ClockMadnessSpec should pass a basic test" in {
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
     //    tester.poke("reset", 0)
     //    tester.poke("io_enable", 1)
     //    for(_ <- 0 until 3) {

--- a/src/test/scala/treadle/chronometry/ClockMadness.scala
+++ b/src/test/scala/treadle/chronometry/ClockMadness.scala
@@ -5,7 +5,6 @@ package treadle.chronometry
 import treadle.TreadleTester
 import org.scalatest.{FreeSpec, Matchers}
 
-
 // scalastyle:off magic.number
 class ClockMadnessSpec extends FreeSpec with Matchers {
   val input =
@@ -40,7 +39,7 @@ class ClockMadnessSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "ClockMadnessSpec should pass a basic test" in {
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
     //    tester.poke("reset", 0)
     //    tester.poke("io_enable", 1)
     //    for(_ <- 0 until 3) {

--- a/src/test/scala/treadle/chronometry/GatedClockSpec.scala
+++ b/src/test/scala/treadle/chronometry/GatedClockSpec.scala
@@ -5,7 +5,6 @@ package treadle.chronometry
 import treadle.TreadleTester
 import org.scalatest.{FreeSpec, Matchers}
 
-
 // scalastyle:off magic.number
 class GatedClockSpec extends FreeSpec with Matchers {
   private val input =
@@ -40,7 +39,7 @@ class GatedClockSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "GatedClockSpec should pass a basic test" in {
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
     // tester.setVerbose()
 
     //    tester.poke("reset", 0)

--- a/src/test/scala/treadle/chronometry/GatedClockSpec.scala
+++ b/src/test/scala/treadle/chronometry/GatedClockSpec.scala
@@ -39,7 +39,7 @@ class GatedClockSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "GatedClockSpec should pass a basic test" in {
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
     // tester.setVerbose()
 
     //    tester.poke("reset", 0)

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -37,10 +37,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
     """
         .stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--firrtl-source", simpleFirrtl)) with HasTreadleSuite
-    val simulator = ExecutionEngine(optionsManager)
+    val simulator = ExecutionEngine(Array("--firrtl-source", simpleFirrtl))
 
     val symbolTable = simulator.symbolTable
 
@@ -79,10 +76,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--firrtl-source", simpleFirrtl)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--firrtl-source", simpleFirrtl))
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -127,10 +121,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--firrtl-source", simpleFirrtl)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--firrtl-source", simpleFirrtl))
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -183,11 +174,8 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--target-dir", "test_run_dir",
-            "--firrtl-source", simpleFirrtl)) with HasTreadleSuite
-    val tester = new TreadleTester(optionsManager)
+    val tester = TreadleTester(Array("--target-dir", "test_run_dir",
+                                     "--firrtl-source", simpleFirrtl))
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -2,7 +2,7 @@
 
 package treadle.executable
 
-import firrtl.CommonOptions
+import firrtl.ExecutionOptionsManager
 import firrtl.graph.CyclicException
 import firrtl.transforms.DontCheckCombLoopsAnnotation
 import treadle._
@@ -37,8 +37,10 @@ class SymbolTableSpec extends FreeSpec with Matchers {
     """
         .stripMargin
 
-    val optionsManager = new TreadleOptionsManager
-    val simulator = ExecutionEngine(simpleFirrtl, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", simpleFirrtl)) with HasTreadleSuite
+    val simulator = ExecutionEngine(optionsManager)
 
     val symbolTable = simulator.symbolTable
 
@@ -77,8 +79,10 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new TreadleOptionsManager
-    val tester = new TreadleTester(simpleFirrtl, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", simpleFirrtl)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -123,8 +127,10 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new TreadleOptionsManager
-    val tester = new TreadleTester(simpleFirrtl, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--firrtl-source", simpleFirrtl)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -177,11 +183,11 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
-    }
-    val tester = new TreadleTester(simpleFirrtl, optionsManager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--target-dir", "test_run_dir",
+            "--firrtl-source", simpleFirrtl)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -256,14 +262,14 @@ class SymbolTableSpec extends FreeSpec with Matchers {
        """
               .stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-      firrtlOptions = firrtlOptions.copy(annotations = firrtlOptions.annotations :+ DontCheckCombLoopsAnnotation)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--target-dir", "test_run_dir",
+            "--firrtl-source", simpleFirrtl),
+      Seq(DontCheckCombLoopsAnnotation)) with HasTreadleSuite
 
     try {
-      val tester = new TreadleTester(simpleFirrtl, optionsManager)
+      val tester = new TreadleTester(optionsManager)
     }
     catch {
       case c: CyclicException =>

--- a/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
+++ b/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
@@ -17,7 +17,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    output c : Fixed
         |    c <= mul(a, b)""".stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("a", BigInt("10", 2))
     tester.poke("b", BigInt("100", 2))
@@ -54,7 +54,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    io_out <= io_in
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("io_in", BigInt("11", 2))
     println(s"got ${tester.peek("io_out")}")
@@ -75,7 +75,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    io.out <= T_2
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
 
     tester.poke("io_in", BigInt("1011", 2))
     println(s"got ${tester.peek("io_out")}")

--- a/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
+++ b/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
@@ -17,10 +17,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    output c : Fixed
         |    c <= mul(a, b)""".stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-    }
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = TreadleTester(input)
 
     tester.poke("a", BigInt("10", 2))
     tester.poke("b", BigInt("100", 2))
@@ -57,10 +54,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    io_out <= io_in
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-    }
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = TreadleTester(input)
 
     tester.poke("io_in", BigInt("11", 2))
     println(s"got ${tester.peek("io_out")}")
@@ -81,11 +75,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    io.out <= T_2
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
+    val tester = TreadleTester(input)
 
     tester.poke("io_in", BigInt("1011", 2))
     println(s"got ${tester.peek("io_out")}")

--- a/src/test/scala/treadle/primops/AndOrXor.scala
+++ b/src/test/scala/treadle/primops/AndOrXor.scala
@@ -156,7 +156,7 @@ class AndOrXor extends FreeSpec with Matchers {
         |
       """.stripMargin
     val bitWidth = 4
-    val tester = new TreadleTester(input)
+    val tester = TreadleTester(input)
     val (lo, hi) = extremaOfSIntOfWidth(bitWidth)
     for {
       a <- lo to hi

--- a/src/test/scala/treadle/primops/AndOrXor.scala
+++ b/src/test/scala/treadle/primops/AndOrXor.scala
@@ -156,7 +156,7 @@ class AndOrXor extends FreeSpec with Matchers {
         |
       """.stripMargin
     val bitWidth = 4
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Array("--firrtl-source", input))
     val (lo, hi) = extremaOfSIntOfWidth(bitWidth)
     for {
       a <- lo to hi

--- a/src/test/scala/treadle/primops/CatBitsHeadTail.scala
+++ b/src/test/scala/treadle/primops/CatBitsHeadTail.scala
@@ -3,10 +3,9 @@
 package treadle.primops
 
 import treadle._
-import treadle.BitTwiddlingUtils
 import treadle.executable._
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class CatBitsHeadTail extends FreeSpec with Matchers {
@@ -91,18 +90,12 @@ class CatBitsHeadTail extends FreeSpec with Matchers {
             |
           """.stripMargin
 
-        val optionsManager = new TreadleOptionsManager {
-          treadleOptions = treadleOptions.copy(
-            writeVCD = false,
-            vcdShowUnderscored = false,
-            setVerbose = false,
-            showFirrtlAtLoad = true,
-            rollbackBuffers = 0,
-            symbolsToWatch = Seq()
-          )
-        }
-
-        val tester = new TreadleTester(input, optionsManager)
+        val optionsManager = new ExecutionOptionsManager(
+          "test",
+          Array("--show-firrtl-at-load",
+                "--fint-rollback-buffers", "0",
+                "--firrtl-source", input)) with HasTreadleSuite
+        val tester = new TreadleTester(optionsManager)
         println(s"peek out 0x${tester.peek("out").toString(16)}")
         tester.report()
       }

--- a/src/test/scala/treadle/real/BlackBoxRealSpec.scala
+++ b/src/test/scala/treadle/real/BlackBoxRealSpec.scala
@@ -3,8 +3,8 @@
 package treadle.real
 
 import treadle._
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FreeSpec, Matchers}
-
 
 class BlackBoxRealSpec extends FreeSpec with Matchers {
   "this tests black box implmentation of real numbers" - {
@@ -37,14 +37,12 @@ class BlackBoxRealSpec extends FreeSpec with Matchers {
 
     "addition should work expand instances as found" in {
 
-      val optionsManager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          setVerbose = false,
-          blackBoxFactories = Seq(new DspRealFactory),
-          randomSeed = 0L
-        )
-      }
-      val tester = new TreadleTester(adderInput, optionsManager)
+      val optionsManager = new ExecutionOptionsManager(
+        "test",
+        Array("--fint-random-seed", "0",
+              "--blackbox-factory", "treadle.real.DspRealFactory",
+              "--firrtl-source", adderInput)) with HasTreadleSuite
+      val tester = new TreadleTester(optionsManager)
 
       tester.poke("io_a1_node", doubleToBigIntBits(1.5))
       tester.poke("io_a2_node", doubleToBigIntBits(3.25))
@@ -73,14 +71,12 @@ class BlackBoxRealSpec extends FreeSpec with Matchers {
         |    BBFIntPart_1.in <= io_a_node
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        blackBoxFactories = Seq(new DspRealFactory),
-        randomSeed = 0L
-      )
-    }
-    val tester = new TreadleTester(input, optionsManager)
+      val optionsManager = new ExecutionOptionsManager(
+        "test",
+        Array("--fint-random-seed", "0",
+              "--blackbox-factory", "treadle.real.DspRealFactory",
+              "--firrtl-source", input)) with HasTreadleSuite
+    val tester = new TreadleTester(optionsManager)
 
     tester.poke("io_a_node", doubleToBigIntBits(3.14159))
 

--- a/src/test/scala/treadle/vcd/VCDSpec.scala
+++ b/src/test/scala/treadle/vcd/VCDSpec.scala
@@ -125,12 +125,9 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
         |    c <= add(a, b)
       """.stripMargin
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--target-dir", "test_run_dir",
-            "--firrtl-source", input)) with HasTreadleSuite
-    val engine = new TreadleTester(optionsManager)
+    val engine = TreadleTester(Array("--fint-write-vcd",
+                                     "--target-dir", "test_run_dir",
+                                     "--firrtl-source", input))
     engine.poke("a", -1)
     engine.peek("a") should be (BigInt(-1))
     engine.poke("b", -7)
@@ -156,13 +153,9 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
     val stream = getClass.getResourceAsStream("/VcdAdder.fir")
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--target-dir", "test_run_dir",
-            "--firrtl-source", input)) with HasTreadleSuite
-
-    val engine = new TreadleTester(optionsManager)
+    val engine = TreadleTester(Array("--fint-write-vcd",
+                                     "--target-dir", "test_run_dir",
+                                     "--firrtl-source", input))
     engine.step()
     engine.poke("io_a", 3)
     engine.poke("io_b", 5)
@@ -208,13 +201,9 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
 
     // logger.Logger.setLevel(LogLevel.Debug)
 
-    val optionsManager = new ExecutionOptionsManager(
-      "test",
-      Array("--fint-write-vcd",
-            "--target-dir", "test_run_dir/vcd_register_delay",
-            "--firrtl-source", input)) with HasTreadleSuite
-
-    val engine = new TreadleTester(optionsManager)
+    val engine = TreadleTester(Array("--fint-write-vcd",
+                                     "--target-dir", "test_run_dir/vcd_register_delay",
+                                     "--firrtl-source", input))
     engine.setVerbose()
     engine.poke("reset", 0)
 

--- a/src/test/scala/treadle/vcd/VCDSpec.scala
+++ b/src/test/scala/treadle/vcd/VCDSpec.scala
@@ -2,8 +2,8 @@
 
 package treadle.vcd
 
-import treadle.{TreadleOptionsManager, TreadleTester}
-import firrtl.CommonOptions
+import treadle.{TreadleOptionsManager, TreadleTester, HasTreadleSuite}
+import firrtl.ExecutionOptionsManager
 import firrtl.util.BackendCompilationUtilities
 import java.io.File
 
@@ -125,11 +125,12 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
         |    c <= add(a, b)
       """.stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(writeVCD = true)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
-    }
-    val engine = new TreadleTester(input, manager)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--target-dir", "test_run_dir",
+            "--firrtl-source", input)) with HasTreadleSuite
+    val engine = new TreadleTester(optionsManager)
     engine.poke("a", -1)
     engine.peek("a") should be (BigInt(-1))
     engine.poke("b", -7)
@@ -155,12 +156,13 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
     val stream = getClass.getResourceAsStream("/VcdAdder.fir")
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(writeVCD = true)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
-    }
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--target-dir", "test_run_dir",
+            "--firrtl-source", input)) with HasTreadleSuite
 
-    val engine = new TreadleTester(input, manager)
+    val engine = new TreadleTester(optionsManager)
     engine.step()
     engine.poke("io_a", 3)
     engine.poke("io_b", 5)
@@ -206,20 +208,20 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
 
     // logger.Logger.setLevel(LogLevel.Debug)
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(writeVCD = true)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir/vcd_register_delay")
-    }
-    {
-      val engine = new TreadleTester(input, manager)
-      engine.setVerbose()
-      engine.poke("reset", 0)
+    val optionsManager = new ExecutionOptionsManager(
+      "test",
+      Array("--fint-write-vcd",
+            "--target-dir", "test_run_dir/vcd_register_delay",
+            "--firrtl-source", input)) with HasTreadleSuite
 
-      engine.step(50)
+    val engine = new TreadleTester(optionsManager)
+    engine.setVerbose()
+    engine.poke("reset", 0)
 
-      engine.report()
-      engine.finish
-    }
+    engine.step(50)
+
+    engine.report()
+    engine.finish
 
 //    Thread.sleep(3000)
 


### PR DESCRIPTION
@chick, @ucbjrl, @jackkoenig: This aligns Treadle with the "Annotations as Options" proposal I've been working on (in the same way that https://github.com/freechipsproject/chisel3/pull/804 aligns Chisel with it).

Fundamentally, this does two things and follows them to their logical conclusion: 
  1. Options are parsed using [scopt's "immutable" approach](https://github.com/scopt/scopt#immutable-parsing) into a `lazy val options: AnnotationSeq` as opposed to [scopt's "mutable" strategy](https://github.com/scopt/scopt#mutable-parsing) (e.g., to directly mutate `var treadleOptions`)
  2. `var treadleOptions` is replaced with `lazy val treadleOptions` determined by examining `options: AnnotationSeq`

This effectively defines a two-stage parsing scheme that can accept mix-ins that define new options. First, an `ExecutionOptionsManager` (with mix-ins defining options) determines an `AnnotationSeq` representing options. Then, each lazy val corresponding to a tool's options (e.g., `treadleOptions`, `firrtlOptions`, `chiselOptions`) will be built by examining the available annotations as needed. Option checking is intended to happen when building these lazy vals, as opposed to by scopt.

To achieve this for Treadle, the following actions are taken:
  - Every option (a member of `TreadleOptions`) must be determined by examining a Treadle-specific annotation (`TreadleOption`)
  - Every annotation can be set with a Treadle command line option
  - Old-style APIs that passed an `OptionsManager` and some other information (like FIRRTL source represented as a string) are either removed or deprecated.

See:
  - FIRRTL issue: https://github.com/freechipsproject/firrtl/issues/764
  - FIRRTL PR: https://github.com/freechipsproject/firrtl/pull/765
  - Chisel PR: https://github.com/freechipsproject/chisel3/pull/804