### PR TITLE
Support for loading memories from files at startup

### DIFF
--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -486,6 +486,17 @@ extends HasDataArrays {
     }
   }
 
+  def update(symbol: Symbol, offset: Int, value: Big): Unit = {
+    if(offset >= symbol.slots) {
+      throw TreadleException(s"assigning to memory ${symbol.name}[$offset] <= $value: index out of range")
+    }
+    symbol.dataSize match {
+      case IntSize  => intData(symbol.index + offset) = value.toInt
+      case LongSize => longData(symbol.index + offset) = value.toLong
+      case BigSize  => bigData(symbol.index + offset) = value
+    }
+  }
+
   //scalastyle:off cyclomatic.complexity method.length
   def serialize: String = {
 

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -82,6 +82,8 @@ class ExecutionEngine(
     }
   }
 
+  val memoryInitializer = new MemoryInitializer(this)
+
   def makeVCDLogger(fileName: String, showUnderscored: Boolean): Unit = {
     val vcd = VCD(ast.main, showUnderscoredNames = showUnderscored)
 
@@ -450,6 +452,8 @@ object ExecutionEngine {
     val total_seconds = (t1 - t0).toDouble / Timer.TenTo9th
     println(s"file loaded in $total_seconds seconds, ${symbolTable.size} symbols, " +
       s"${scheduler.combinationalAssigns.size} statements")
+
+    executionEngine.memoryInitializer.initializeMemoriesFromFiles()
 
     executionEngine
   }

--- a/src/main/scala/treadle/executable/Memory.scala
+++ b/src/main/scala/treadle/executable/Memory.scala
@@ -6,6 +6,7 @@ import treadle._
 import firrtl.{MemKind, WireKind}
 import firrtl.ir.{ClockType, DefMemory, Info, IntWidth}
 import RenderHelper.ExpressionHelper
+import firrtl.annotations.{ComponentName, LoadMemoryAnnotation, MemoryLoadFileType, ModuleName}
 
 import scala.collection.mutable
 
@@ -590,6 +591,52 @@ object Memory {
       )
     }
   }
+}
 
+class MemoryInitializer(engine: ExecutionEngine) {
+  case class MemoryMetadata(symbol: Symbol, fileName: String, radix: Int)
 
+  val memoryLoadAnnotations: Seq[LoadMemoryAnnotation] = engine.optionsManager.firrtlOptions.annotations.collect {
+    case mla: LoadMemoryAnnotation => mla
+  }
+
+  /*
+  module containing a memory may have been instantiated multiple times
+  This makes sure that every instance of the memory gets loaded
+   */
+  val memoryMetadata: Seq[MemoryMetadata] = memoryLoadAnnotations.flatMap { anno =>
+    anno.target match {
+      case ComponentName(memoryName, ModuleName(moduleName, _)) =>
+        val radix = anno.hexOrBinary match {
+          case MemoryLoadFileType.Hex => 16
+          case MemoryLoadFileType.Binary => 2
+        }
+        engine.symbolTable.moduleMemoryToMemorySymbol(s"$moduleName.$memoryName").toSeq.map { memorySymbol =>
+          MemoryMetadata(memorySymbol, anno.getFileName, radix)
+        }
+      case _ => Seq()
+    }
+  }
+
+  private def doInitialize(memorySymbol: Symbol, fileName: String, radix: Int): Unit = {
+    io.Source.fromFile(fileName).getLines().zipWithIndex.foreach {
+      case (line, lineNumber) if lineNumber < memorySymbol.slots =>
+        try {
+          val value = BigInt(line.trim, radix)
+          engine.dataStore.update(memorySymbol, lineNumber, value)
+        }
+        catch {
+          case t: TreadleException => throw t
+          case t: Throwable =>
+            throw TreadleException(s"loading memory ${memorySymbol.name}[$lineNumber] <= $line: error: ${t.getMessage}")
+        }
+      case _ =>
+    }
+  }
+
+  def initializeMemoriesFromFiles(): Unit = {
+    memoryMetadata.foreach { metadata =>
+      doInitialize(metadata.symbol, metadata.fileName, metadata.radix)
+    }
+  }
 }

--- a/src/test/scala/treadle/MemoryUsageSpec.scala
+++ b/src/test/scala/treadle/MemoryUsageSpec.scala
@@ -1,6 +1,10 @@
 // See LICENSE for license details.
 package treadle
 
+import java.io.{File, PrintWriter}
+
+import firrtl.FileUtils
+import firrtl.annotations.{CircuitName, ComponentName, LoadMemoryAnnotation, ModuleName}
 import org.scalatest.{FreeSpec, Matchers}
 
 /**
@@ -388,5 +392,81 @@ class MemoryUsageSpec extends FreeSpec with Matchers {
 
       tester.report()
     }
+  }
+
+  "memory can be initialized at startup" in {
+    val input =
+      """
+        |circuit UsesMem :
+        |  module UsesMemLow :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output io : {flip address : UInt<16>, value : UInt<16>}
+        |
+        |    cmem memory : UInt<16>[8] @[LoadMemoryFromFileSpec.scala 42:19]
+        |    node _T_8 = bits(io.address, 2, 0) @[LoadMemoryFromFileSpec.scala 46:21]
+        |    infer mport _T_9 = memory[_T_8], clock @[LoadMemoryFromFileSpec.scala 46:21]
+        |    io.value <= _T_9 @[LoadMemoryFromFileSpec.scala 46:12]
+        |
+        |  module UsesMem :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output io : {flip address : UInt<16>, value : UInt<16>, value2 : UInt<16>}
+        |
+        |    cmem memory : UInt<16>[8] @[LoadMemoryFromFileSpec.scala 24:19]
+        |    node _T_8 = bits(io.address, 2, 0) @[LoadMemoryFromFileSpec.scala 28:21]
+        |    infer mport _T_9 = memory[_T_8], clock @[LoadMemoryFromFileSpec.scala 28:21]
+        |    io.value <= _T_9 @[LoadMemoryFromFileSpec.scala 28:12]
+        |    inst low of UsesMemLow @[LoadMemoryFromFileSpec.scala 30:19]
+        |    low.clock <= clock
+        |    low.reset <= reset
+        |    low.io.address <= io.address @[LoadMemoryFromFileSpec.scala 32:18]
+        |    io.value2 <= low.io.value @[LoadMemoryFromFileSpec.scala 33:13]
+      """.stripMargin
+
+    val targetDirName = "test_run_dir/load_mem_test"
+    FileUtils.makeDirectory(targetDirName)
+
+    val memoryAnnotations = Seq(
+      LoadMemoryAnnotation(
+        ComponentName("memory", ModuleName("UsesMem", CircuitName("UsesMem"))), s"$targetDirName/mem1"
+      ),
+      LoadMemoryAnnotation(
+        ComponentName("memory", ModuleName("UsesMemLow", CircuitName("UsesMem"))), s"$targetDirName/mem2"
+      )
+    )
+    val optionsManager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        setVerbose = false,
+        showFirrtlAtLoad = false,
+        callResetAtStartUp = true
+      )
+      firrtlOptions = firrtlOptions.copy(
+        annotations = firrtlOptions.annotations ++ memoryAnnotations
+      )
+      commonOptions = commonOptions.copy(targetDirName = "test_run_dir", topName = "load_mem_test")
+    }
+
+    val writer = new PrintWriter(new File(s"$targetDirName/mem1"))
+    for(i <- 0 until 8) {
+      writer.println(i)
+    }
+    writer.close()
+
+    val writer2 = new PrintWriter(new File(s"$targetDirName/mem2"))
+    for(i <- 0 until 8) {
+      writer2.println(7 - i)
+    }
+    writer2.close()
+
+    val tester = new TreadleTester(input, optionsManager)
+
+    for(i <- 0 until 8) {
+      tester.expectMemory("memory", i, i)
+      tester.expectMemory("low.memory", i, 7 - i)
+
+    }
+    tester.report()
+    tester.finish
   }
 }


### PR DESCRIPTION
- Provide an update method for loading memory at offset
- Create memory initializer
  - keeps track of memories tagged for loading at start-up
  - initializes them, could be re-done by REPL
- symbol table builds list of modules with memories to load
- bit of additional logic to match memories with modules
- add simple test to validate some of this logic