### PR TITLE
Bug Fixes from Field training Sep 11 2018

### DIFF
--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -52,7 +52,11 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
   var currentTreadleTesterOpt: Option[TreadleTester] = None
   def currentTreadleTester: TreadleTester = currentTreadleTesterOpt.get
 
-  def engine: ExecutionEngine = currentTreadleTesterOpt.get.engine
+  def engine: ExecutionEngine = currentTreadleTesterOpt match {
+    case Some(tester) => tester.engine
+    case _ =>
+      throw TreadleException(s"No file currently loaded")
+  }
 
   var args = Array.empty[String]
   var done = false
@@ -395,7 +399,7 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
         }
         def run(args: Array[String]): Unit = {
           args.toList match {
-            case "load" :: fileName :: tail =>
+            case "load" :: fileName :: _ =>
               loadVcdScript(fileName)
             case _ =>
               replVcdController match {
@@ -775,6 +779,21 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
       new Command("waitfor") {
         def usage: (String, String) = ("waitfor componentName value [maxNumberOfSteps]",
           "wait for particular value (default 1) on component, up to maxNumberOfSteps (default 100)")
+
+        override def completer: Option[ArgumentCompleter] = {
+          if(currentTreadleTesterOpt.isEmpty) {
+            None
+          }
+          else {
+            Some(new ArgumentCompleter(
+              new StringsCompleter({
+                "waitfor"
+              }),
+              new StringsCompleter(jlist(engine.validNames.toSeq))
+            ))
+          }
+        }
+
         def run(args: Array[String]): Unit = {
           getThreeArgs(
             "waitfor componentName [value] [maxNumberOfSteps]",
@@ -794,7 +813,7 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
                 if(engine.getValue(componentName) != BigInt(value)) {
                   console.println(
                     s"waitfor exhausted $componentName did not take on" +
-                            " value ${formatOutput(value)} in $maxNumberOfSteps cycles")
+                      s" value ${formatOutput(value)} in $maxNumberOfSteps cycles")
                 }
                 else {
                   console.println(s"$componentName == value ${formatOutput(value)} in $tries cycles")
@@ -858,7 +877,7 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
         }
       },
       new Command("show") {
-        def usage: (String, String) = ("show [state|input|lofirrtl]", "show useful things")
+        def usage: (String, String) = ("show [state|input|inputs|outputs|firrtl|lofirrtl]", "show useful things")
         override def completer: Option[ArgumentCompleter] = {
           if(currentTreadleTesterOpt.isEmpty) {
             None
@@ -866,7 +885,7 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
           else {
             Some(new ArgumentCompleter(
               new StringsCompleter({ "show"}),
-              new StringsCompleter(jlist(Seq("state", "input", "lofirrtl")))
+              new StringsCompleter(jlist(Seq("state", "input", "inputs", "outputs", "firrtl", "lofirrtl")))
             ))
           }
         }
@@ -875,15 +894,19 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
           getOneArg("", Some("state")) match {
             case Some("lofirrtl") =>
               console.println(engine.ast.serialize)
-            case Some("input") =>
+            case Some("input") | Some("firrtl") =>
               console.println(engine.ast.serialize)
+            case Some("inputs") =>
+              console.println(engine.symbolTable.inputPortsNames.toSeq.sorted.mkString("\n"))
+            case Some("outputs") =>
+              console.println(engine.symbolTable.outputPortsNames.toSeq.sorted.mkString("\n"))
             case _ =>
               console.println(engine.getPrettyString)
           }
         }
       },
       new Command("display") {
-        def usage: (String, String) = ("how signal[, signal, ...]", "show computation of symbols")
+        def usage: (String, String) = ("display signal[, signal, ...]", "show computation of symbols")
         override def completer: Option[ArgumentCompleter] = {
           if(currentTreadleTesterOpt.isEmpty) {
             None

--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -10,6 +10,7 @@ import logger.Logger
 import treadle.chronometry.UTC
 import treadle.executable.{ClockInfo, ExecutionEngine, Symbol, TreadleException}
 import treadle.repl._
+import treadle.utils.ToLoFirrtl
 
 import scala.collection.mutable.ArrayBuffer
 import scala.tools.jline.console.ConsoleReader
@@ -877,7 +878,7 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
         }
       },
       new Command("show") {
-        def usage: (String, String) = ("show [state|input|inputs|outputs|firrtl|lofirrtl]", "show useful things")
+        def usage: (String, String) = ("show [state|inputs|outputs|firrtl|lofirrtl]", "show useful things")
         override def completer: Option[ArgumentCompleter] = {
           if(currentTreadleTesterOpt.isEmpty) {
             None
@@ -885,15 +886,15 @@ class TreadleRepl(val optionsManager: TreadleOptionsManager with HasReplConfig) 
           else {
             Some(new ArgumentCompleter(
               new StringsCompleter({ "show"}),
-              new StringsCompleter(jlist(Seq("state", "input", "inputs", "outputs", "firrtl", "lofirrtl")))
+              new StringsCompleter(jlist(Seq("state", "inputs", "outputs", "firrtl", "lofirrtl")))
             ))
           }
         }
 
         def run(args: Array[String]): Unit = {
-          getOneArg("", Some("state")) match {
+          getOneArg("", Some("lofirrtl")) match {
             case Some("lofirrtl") =>
-              console.println(engine.ast.serialize)
+              console.println(ToLoFirrtl.lower(engine.ast, optionsManager).serialize)
             case Some("input") | Some("firrtl") =>
               console.println(engine.ast.serialize)
             case Some("inputs") =>

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -155,7 +155,9 @@ extends HasDataArrays {
   case class AssignInt(symbol: Symbol, expression: FuncInt, info: Info) extends Assigner {
     val index: Int = symbol.index
 
-    def runLean(): Unit = {intData(index) = expression() }
+    def runLean(): Unit = {
+      intData(index) = expression()
+    }
 
     def runFull(): Unit = {
       val value = expression()

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -39,7 +39,9 @@ class ExecutionEngine(
   /* Default dataStore plugins */
 
   dataStore.addPlugin(
-    "show-assigns", new ReportAssignments(this), enable = optionsManager.treadleOptions.setVerbose)
+    "show-assigns", new ReportAssignments(this),
+    enable = optionsManager.treadleOptions.setVerbose
+  )
 
   dataStore.addPlugin(
     "show-computation",
@@ -62,6 +64,10 @@ class ExecutionEngine(
   def setVerbose(isVerbose: Boolean = true): Unit = {
     verbose = isVerbose
     setLeanMode()
+    dataStore.plugins.get("show-assigns") match {
+      case Some(plugin) => plugin.setEnabled(verbose)
+      case _ => None
+    }
     scheduler.setVerboseAssign(isVerbose)
   }
 

--- a/src/test/scala/treadle/chronometry/ClockCrossingSpec.scala
+++ b/src/test/scala/treadle/chronometry/ClockCrossingSpec.scala
@@ -4,7 +4,6 @@ package treadle.chronometry
 
 import firrtl.{Driver, ExecutionOptionsManager}
 import firrtl.{FirrtlExecutionSuccess, HasFirrtlOptions, Parser}
-import firrtl.passes.CheckChirrtl
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.ClockInfo
 import treadle.{TreadleOptionsManager, TreadleTester}


### PR DESCRIPTION
- Make it easier to breakpoint in AssignInt
- Enable show-assigns plugin when debug enabled
- Give better error when setting verbose but file not loaded
- Added completions to waitfor command
- Fixed message in waitfor command
- Add inputs and outputs to show command
- fixed wording in help for display command
- Remove CheckChirrtl import for ClockCrossingSpec