### PR TITLE
Better clock handling

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -80,6 +80,12 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
       new MultiClockStepper(engine = this.engine, clockInfoList, wallTime)
   }
 
+  /**
+    * Advance time in ticks of the [[UTC]] wallTime, the default is picoseconds, but can be
+    * read by the scaleName of the wallTime.  One should probably be advancing by some simple factor
+    * of a clock period. The clockInfoList of the options should define this (could be more than one).
+    * @param interval units are in units of the [[wallTime]] scale.
+    */
   def advanceTime(interval: Long): Unit = {
     assert(interval >= 0L, "TreadleTester#advanceTime called with negative value")
     wallTime.setTime(wallTime.currentTime + interval)

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -80,6 +80,11 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
       new MultiClockStepper(engine = this.engine, clockInfoList, wallTime)
   }
 
+  def advanceTime(interval: Long): Unit = {
+    assert(interval >= 0L, "TreadleTester#advanceTime called with negative value")
+    wallTime.setTime(wallTime.currentTime + interval)
+  }
+
   /*
   The Idea here is that combinational delay will be used when a peek follows a poke without a step
   This should allow VCD output to show the events as if they had taken place in a small

--- a/src/main/scala/treadle/chronometry/UTC.scala
+++ b/src/main/scala/treadle/chronometry/UTC.scala
@@ -6,7 +6,7 @@ import treadle.utils.Render
 
 import scala.collection.mutable
 
-class UTC(scaleName: String = "picoseconds") {
+class UTC(val scaleName: String = "picoseconds") {
   private var internalTime: Long = 0L
   def currentTime:  Long = internalTime
   def setTime(time: Long): Unit = {

--- a/src/test/scala/treadle/ClockedManuallySpec.scala
+++ b/src/test/scala/treadle/ClockedManuallySpec.scala
@@ -122,29 +122,4 @@ class ClockedManuallySpec extends FreeSpec with Matchers {
     tester.report()
   }
 
-  "treadle should update register at right time" in {
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = true,
-        vcdShowUnderscored = true,
-        writeVCD = true,
-        callResetAtStartUp = false
-      )
-      commonOptions = commonOptions.copy(
-        targetDirName = "test_run_dir/auto_clocked/clock_up",
-        topName = "clock_up"
-      )
-    }
-
-    val tester = new TreadleTester(input, optionsManager)
-
-    tester.poke("in1", 1)
-    tester.step()
-    tester.poke("in1", 2)
-    tester.step()
-    tester.poke("in1", 1)
-
-    tester.report()
-  }
-
 }

--- a/src/test/scala/treadle/ClockedManuallySpec.scala
+++ b/src/test/scala/treadle/ClockedManuallySpec.scala
@@ -1,0 +1,150 @@
+// See LICENSE for license details.
+
+package treadle
+
+import org.scalatest.{FreeSpec, Matchers}
+
+
+// scalastyle:off magic.number
+class ClockedManuallySpec extends FreeSpec with Matchers {
+
+  private val input =
+    """
+      |circuit ManuallyClocked :
+      |  module ManuallyClocked :
+      |    input clock : Clock
+      |    input reset : UInt<1>
+      |    input in1 : UInt<8>
+      |    output out_direct : UInt<8>
+      |    output out_from_reg : UInt<8>
+      |    output inverted_clock : Clock
+      |    output out_from_neg_edge_reg : UInt<8>
+      |
+      |    reg reg1 : UInt<8>, clock with : (reset => (reset, UInt<8>("h03")))
+      |    reg reg2 : UInt<8>, inverted_clock with : (reset => (reset, UInt<8>("h07")))
+      |
+      |    out_direct <= in1
+      |
+      |    reg1 <= in1
+      |    out_from_reg <= reg1
+      |
+      |    reg2 <= in1
+      |    out_from_neg_edge_reg <= reg2
+      |
+      |    inverted_clock <= asClock(not(asUInt(clock)))
+      |
+      """.stripMargin
+
+  "Circuit can be run, just with poking and time advance" in {
+
+    val optionsManager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        setVerbose = false,
+        vcdShowUnderscored = true,
+        writeVCD = true
+      )
+    }
+
+    val tester = new TreadleTester(input, optionsManager)
+
+    tester.advanceTime(300)
+
+    tester.poke("clock", 0)
+    tester.poke("reset", 0)
+    tester.poke("in1", 0)
+
+    tester.expect("out_direct", 0)
+    tester.expect("out_from_reg", 0)
+    tester.expect("inverted_clock", 1)
+
+    tester.advanceTime(100)
+
+    tester.poke("in1", 3)
+
+    tester.expect("out_direct", 3)
+    tester.expect("out_from_reg", 0)
+    tester.expect("inverted_clock", 1)
+
+    tester.poke("clock", 1)
+
+    tester.expect("out_direct", 3)
+    tester.expect("out_from_reg", 3)
+    tester.expect("inverted_clock", 0)
+
+    tester.advanceTime(100)
+
+    tester.expect("out_direct", 3)
+    tester.expect("out_from_reg", 3)
+    tester.expect("inverted_clock", 0)
+
+    tester.report()
+  }
+
+  "clock up should advance registers off negative edge" in {
+
+    val optionsManager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        setVerbose = true,
+        vcdShowUnderscored = true,
+        writeVCD = true
+      )
+      commonOptions = commonOptions.copy(
+        targetDirName = "test_run_dir/manually_clocked/clock_up",
+        topName = "clock_up"
+      )
+    }
+
+    val tester = new TreadleTester(input, optionsManager)
+
+    tester.advanceTime(10)
+
+    tester.poke("in1", 1)
+    tester.poke("clock", 1)
+    tester.poke("reset", 0)
+
+    tester.expect("out_direct", 1)
+    tester.expect("out_from_reg", 1)
+    tester.expect("inverted_clock", 0)
+
+    tester.advanceTime(10)
+
+    tester.poke("in1", 2)
+    tester.poke("clock", 0)
+
+    tester.expect("out_direct", 2)
+    tester.expect("out_from_reg", 1)
+    tester.expect("inverted_clock", 1)
+
+    tester.advanceTime(10)
+
+    tester.poke("in1", 1)
+
+    tester.report()
+  }
+
+  "treadle should update register at right time" in {
+    val optionsManager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        setVerbose = true,
+        vcdShowUnderscored = true,
+        writeVCD = true,
+        callResetAtStartUp = false
+      )
+      commonOptions = commonOptions.copy(
+        targetDirName = "test_run_dir/auto_clocked/clock_up",
+        topName = "clock_up"
+      )
+    }
+
+    val tester = new TreadleTester(input, optionsManager)
+
+    tester.poke("in1", 1)
+    tester.step()
+    tester.poke("in1", 2)
+    tester.step()
+    tester.poke("in1", 1)
+
+    tester.report()
+  }
+
+}


### PR DESCRIPTION
- Add advanceTime method to API for precise control of multi-clock DUT
- If signal poked a second time without time or clock advance, evaluate circuit
- Fix scalastyle in engine
- Check transition on triggered assign, and update if up transition
- Add tests for use of advanceTime API