### PR TITLE
One pass execution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,9 @@ organization := "edu.berkeley.cs"
 
 version := "1.1-SNAPSHOT"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
-crossScalaVersions := Seq("2.12.6", "2.11.12")
+crossScalaVersions := Seq("2.12.7", "2.11.12")
 
 // enables using control-c in sbt CLI
 cancelable in Global := true
@@ -44,6 +44,17 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("public")
 )
+
+// Assembly
+
+assemblyJarName in assembly := "treadle.jar"
+
+mainClass in assembly := Some("treadle.TreadleRepl")
+
+test in assembly := {} // Should there be tests?
+
+assemblyOutputPath in assembly := file("./utils/bin/treadle.jar")
+
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map("firrtl" -> "1.2-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 logLevel := Level.Warn
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/src/main/scala/treadle/Regression.scala
+++ b/src/main/scala/treadle/Regression.scala
@@ -1,0 +1,106 @@
+// See LICENSE for license details.
+
+package treadle
+
+object Regression {
+  def computeGcd(a: Int, b: Int): (Int, Int) = {
+    var x = a
+    var y = b
+    var depth = 1
+    while(y > 0 ) {
+      if (x > y) {
+        x -= y
+      }
+      else {
+        y -= x
+      }
+      depth += 1
+    }
+    (x, depth)
+  }
+
+  //scalastyle:off method.length
+  def manyValuesTest(width: Int) {
+    val gcdFirrtl: String =
+      s"""
+         |circuit GCD :
+         |  module GCD :
+         |    input clock : Clock
+         |    input reset : UInt<1>
+         |    input io_a : UInt<$width>
+         |    input io_b : UInt<$width>
+         |    input io_e : UInt<1>
+         |    output io_z : UInt<$width>
+         |    output io_v : UInt<1>
+         |    reg x : UInt<$width>, clock with :
+         |      reset => (UInt<1>("h0"), x)
+         |    reg y : UInt<$width>, clock with :
+         |      reset => (UInt<1>("h0"), y)
+         |    node T_13 = gt(x, y)
+         |    node T_14 = sub(x, y)
+         |    node T_15 = tail(T_14, 1)
+         |    node T_17 = eq(T_13, UInt<1>("h0"))
+         |    node T_18 = sub(y, x)
+         |    node T_19 = tail(T_18, 1)
+         |    node T_21 = eq(y, UInt<1>("h0"))
+         |    node GEN_0 = mux(T_13, T_15, x)
+         |    x <= mux(io_e, io_a, GEN_0)
+         |    node GEN_1 = mux(T_17, T_19, y)
+         |    y <= mux(io_e, io_b, GEN_1)
+         |    io_z <= x
+         |    io_v <= T_21
+    """
+              .stripMargin
+
+    val manager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        showFirrtlAtLoad = false,
+        setVerbose = false,
+        rollbackBuffers = 0
+      )
+    }
+
+    val values =
+      for {x <- 1 to 1000
+           y <- 1 to 100
+      } yield (x, y, computeGcd(x, y)._1)
+
+    val tester = new TreadleTester(gcdFirrtl, manager)
+
+    val startTime = System.nanoTime()
+    tester.poke("clock", 1)
+
+    for((x, y, z) <- values) {
+      tester.step()
+      tester.poke("io_a", x)
+      tester.poke("io_b", y)
+      tester.poke("io_e", 1)
+      tester.step()
+
+      tester.poke("io_e", 0)
+      tester.step()
+
+      while (tester.peek("io_v") != Big1) {
+        tester.step()
+      }
+
+      tester.expect("io_z", z)
+    }
+    val endTime = System.nanoTime()
+    val elapsedSeconds = (endTime - startTime).toDouble / 1000000000.0
+
+    val cycle = tester.cycleCount
+
+    println(
+      f"processed $cycle cycles $elapsedSeconds%.6f seconds ${cycle.toDouble / (1000000.0 * elapsedSeconds)}%5.3f MHz"
+    )
+    tester.report()
+  }
+
+
+
+
+  def main(args: Array[String]): Unit = {
+    manyValuesTest(20)
+  }
+}

--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -25,6 +25,9 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.JsonDSL._
 
+
+//TODO: show inputs/outputs should show values also
+
 abstract class Command(val name: String) {
   def run(args: Array[String]): Unit
   def usage: (String, String)

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -130,14 +130,12 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = TreadleTest
   if(optionsManager.treadleOptions.callResetAtStartUp && engine.symbolTable.contains(resetName)) {
     clockInfoList.headOption.foreach { clockInfo =>
       reset(clockInfo.period + clockInfo.initialOffset)
-//      reset(clockInfo.period + clockInfo.initialOffset - (clockInfo.period / 2)) // once found this to help on a test
     }
   }
 
   def reset(timeRaised: Long): Unit = {
     engine.symbolTable.get(resetName).foreach { resetSymbol =>
       engine.setValue(resetName, 1)
-      engine.inputsChanged = true
 
       clockStepper match {
         case _: NoClockStepper =>
@@ -151,7 +149,6 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = TreadleTest
             if (engine.verbose) {
               println(s"reset dropped at ${wallTime.currentTime}")
             }
-            engine.inputsChanged = true
             engine.evaluateCircuit()
           }
           while(engine.dataStore(resetSymbol) != Big0) {
@@ -164,7 +161,6 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = TreadleTest
             if (engine.verbose) {
               println(s"reset dropped at ${wallTime.currentTime}")
             }
-            engine.inputsChanged = true
           }
           wallTime.runUntil(wallTime.currentTime + timeRaised)
       }

--- a/src/main/scala/treadle/executable/BlackBoxCycler.scala
+++ b/src/main/scala/treadle/executable/BlackBoxCycler.scala
@@ -11,23 +11,23 @@ import treadle.ScalaBlackBox
   * @param symbol symbol name of instance
   * @param blackBox the instance
   * @param clockSymbol clock used by instance
-  * @param dataStore the data
   * @param info source location
   */
 //TODO: This should be called everytime something hanppens to clock and should indicate all possible transitions
 case class BlackBoxCycler(
-  symbol      : Symbol,
-  blackBox    : ScalaBlackBox,
-  clockSymbol : Symbol,
-  dataStore   : DataStore,
-  info        : Info
+  symbol:                Symbol,
+  blackBox:              ScalaBlackBox,
+  clockSymbol:           Symbol,
+  clockTransitionGetter: ClockTransitionGetter,
+  info:                  Info
 )
 extends Assigner {
 
   override def run: FuncUnit = {
-    blackBox.clockChange(PositiveEdge, clockSymbol.name)
+    val transition = clockTransitionGetter.transition
+    blackBox.clockChange(transition, clockSymbol.name)
     if (isVerbose) {
-      println(s"${symbol.name} : black box cycle($PositiveEdge)")
+      println(s"${symbol.name} : clock ${clockSymbol.name} state ($transition)")
     }
     () => Unit
   }

--- a/src/main/scala/treadle/executable/ClockStepper.scala
+++ b/src/main/scala/treadle/executable/ClockStepper.scala
@@ -108,7 +108,7 @@ case class SimpleSingleClockStepper(
       * Raise the clock and propagate changes
       */
     def raiseClock(): Unit = {
-      engine.setValue(clockSymbol.name, 1)
+      engine.setIntValue(clockSymbol, 1)
       engine.evaluateCircuit()
 
       val remainingIncrement = handlePossibleReset(upPeriod)
@@ -121,7 +121,7 @@ case class SimpleSingleClockStepper(
       * lower the clock
       */
     def lowerClock(): Unit = {
-      engine.setValue(clockSymbol.name, 0)
+      engine.setIntValue(clockSymbol, 0)
       combinationalBumps = 0L
     }
 

--- a/src/main/scala/treadle/executable/ClockStepper.scala
+++ b/src/main/scala/treadle/executable/ClockStepper.scala
@@ -2,7 +2,6 @@
 
 package treadle.executable
 
-import firrtl.ir.NoInfo
 import treadle.chronometry.UTC
 import treadle.utils.Render
 

--- a/src/main/scala/treadle/executable/ClockStepper.scala
+++ b/src/main/scala/treadle/executable/ClockStepper.scala
@@ -61,7 +61,7 @@ case class SimpleSingleClockStepper(
   override def bumpClock(clockSymbol: Symbol, value: BigInt): Unit = {
     if(hasRollBack) {
       // save data state under roll back buffers for this clock
-      engine.dataStore.saveData(clockSymbol.name, wallTime.currentTime)
+      engine.dataStore.saveData(wallTime.currentTime)
     }
 
     engine.setValue(clockSymbol.name, value)
@@ -91,7 +91,6 @@ case class SimpleSingleClockStepper(
 
         resetSymbolOpt.foreach { resetSymbol =>
           engine.setValue(resetSymbol.name, 0)
-          engine.inputsChanged = true
           if(increment - incrementToReset > 0) {
             engine.evaluateCircuit()
           }
@@ -150,11 +149,6 @@ case class SimpleSingleClockStepper(
 
       wallTime.incrementTime(remainingIncrement)
 
-      if (hasRollBack) {
-        // save data state under roll back buffers for this clock
-        engine.dataStore.saveData(clockSymbol.name, wallTime.currentTime)
-      }
-
       raiseClock()
 
       lowerClock()
@@ -194,10 +188,6 @@ class MultiClockStepper(engine: ExecutionEngine, clockInfoList: Seq[ClockInfo], 
 
     // this sets clock high and will call register updates
     wallTime.addRecurringTask(clockInfo.period, clockInfo.initialOffset, s"${clockInfo.name}/up") { () =>
-      if(hasRollBack) {
-        // save data state under roll back buffers for this clock
-        engine.dataStore.saveData(clockInfo.name, wallTime.currentTime)
-      }
       cycleCount += 1
       engine.setValue(clockSymbol.name, BigInt(1))
     }
@@ -222,7 +212,7 @@ class MultiClockStepper(engine: ExecutionEngine, clockInfoList: Seq[ClockInfo], 
     if(value > Big(0)) {
       if(hasRollBack) {
         // save data state under roll back buffers for this clock
-        engine.dataStore.saveData(clockSymbol.name, wallTime.currentTime)
+        engine.dataStore.saveData(wallTime.currentTime)
       }
       assigner.upAssigner.run()
     }

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -143,6 +143,10 @@ class ExecutionEngine(
   private def runAssigns(): Unit = {
     try {
       scheduler.executeCombinationalAssigns()
+
+      // save data state under roll back buffers if they are being used
+      dataStore.saveData(wallTime.currentTime)
+
       if(lastStopResult.isDefined) {
         writeVCD()
         val stopKind = if(lastStopResult.get > 0) { "Failure Stop" } else { "Stopped" }
@@ -286,6 +290,7 @@ class ExecutionEngine(
         Render.headerBar(s"combinational evaluate", offset = 8)
       }
       runAssigns()
+
       if(verbose) {
         Render.headerBar(s"done combinational evaluate", offset = 8)
       }
@@ -466,6 +471,7 @@ object ExecutionEngine {
       scheduler.setVerboseAssign(verbose)
     }
 
+    // Do this to make sure inits and what-not happen
     executionEngine.inputsChanged = true
 
     val t1 = System.nanoTime()

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -95,7 +95,7 @@ class ExecutionEngine(
   val memoryInitializer = new MemoryInitializer(this)
 
   def makeVCDLogger(fileName: String, showUnderscored: Boolean): Unit = {
-    val vcd = VCD(ast.main, showUnderscoredNames = showUnderscored)
+    val vcd = VCD(ast.main, showUnderscoredNames = ! showUnderscored)
 
     symbolTable.instanceNames.foreach { name =>
       vcd.scopeRoot.addScope(name)

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -210,7 +210,6 @@ class ExecutionEngine(
       }
       symbolsPokedSinceEvaluation.clear()
       scheduler.executeCombinationalAssigns()
-      scheduler.executeTriggeredAssigns(symbol)
     }
     symbolsPokedSinceEvaluation += symbol
 
@@ -232,15 +231,6 @@ class ExecutionEngine(
       dataStore.update(symbol, adjustedValue)
       vcdOption.foreach { vcd =>
         vcd.wireChanged(symbol.name, dataStore(symbol), symbol.bitWidth)
-      }
-
-      if(
-        scheduler.triggeredAssigns.contains(symbol) &&
-        currentValue == Big0 && adjustedValue == Big1
-      ) {
-
-        scheduler.executeCombinationalAssigns()
-        scheduler.executeTriggeredAssigns(symbol)
       }
     }
     else {

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -95,7 +95,7 @@ class ExecutionEngine(
   val memoryInitializer = new MemoryInitializer(this)
 
   def makeVCDLogger(fileName: String, showUnderscored: Boolean): Unit = {
-    val vcd = VCD(ast.main, showUnderscoredNames = ! showUnderscored)
+    val vcd = VCD(ast.main, showUnderscoredNames = showUnderscored)
 
     symbolTable.instanceNames.foreach { name =>
       vcd.scopeRoot.addScope(name)

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -683,7 +683,7 @@ class ExpressionCompiler(
             val prevClockAssigner = dataStore.AssignInt(
               prevClockSymbol, makeGet(assignedSymbol).asInstanceOf[IntExpressionResult].apply, info = con.info
             )
-            scheduler.endOfCycleAssigns += prevClockAssigner
+            scheduler.addEndOfCycleAssigner(prevClockAssigner)
           }
         }
 
@@ -752,7 +752,7 @@ class ExpressionCompiler(
           val prevClockAssigner = dataStore.AssignInt(
             prevClockSymbol, makeGet(symbol).asInstanceOf[IntExpressionResult].apply, info
           )
-          scheduler.endOfCycleAssigns += prevClockAssigner
+          scheduler.addEndOfCycleAssigner(prevClockAssigner)
         }
 
       case DefWire(_, name, _) =>
@@ -863,7 +863,7 @@ class ExpressionCompiler(
         val prevClockAssigner = dataStore.AssignInt(
           prevClockSymbol, makeGet(clockSymbol).asInstanceOf[IntExpressionResult].apply, info = NoInfo
         )
-        scheduler.endOfCycleAssigns += prevClockAssigner
+        scheduler.addEndOfCycleAssigner(prevClockAssigner)
       }
     }
   }

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -84,33 +84,21 @@ class ExpressionCompiler(
 
   //scalastyle:off cyclomatic.complexity method.length
   def makeAssigner(
-    symbol: Symbol,
-    expressionResult: ExpressionResult,
-    triggerOption: Option[Symbol] = None,
-    info: Info
+    symbol                : Symbol,
+    expressionResult      : ExpressionResult,
+    conditionalClockSymbol: Option[Symbol] = None,
+    info                  : Info
   ): Unit = {
     val assigner = (symbol.dataSize, expressionResult) match {
       case (IntSize,  result: IntExpressionResult)  =>
-        if(scheduler.isTrigger(symbol)) {
-          dataStore.TriggerExpressionAssigner(symbol, scheduler, result.apply, triggerOnValue = 1, info)
-        }
-        else {
-          dataStore.AssignInt(symbol, result.apply, info)
-        }
+        dataStore.AssignInt(symbol, result.apply, info)
+
       case (IntSize,  result: LongExpressionResult) =>
-        if(scheduler.isTrigger(symbol)) {
-          dataStore.TriggerExpressionAssigner(symbol, scheduler, ToInt(result.apply).apply, triggerOnValue = 1, info)
-        }
-        else {
           dataStore.AssignInt(symbol,  ToInt(result.apply).apply, info)
-        }
+
       case (IntSize,  result: BigExpressionResult)  =>
-        if(scheduler.isTrigger(symbol)) {
-          dataStore.TriggerExpressionAssigner(symbol, scheduler, ToInt(result.apply).apply, triggerOnValue = 1, info)
-        }
-        else {
           dataStore.AssignInt(symbol,  ToInt(result.apply).apply, info)
-        }
+
       case (LongSize, result: IntExpressionResult)  => dataStore.AssignLong(symbol, ToLong(result.apply).apply, info)
       case (LongSize, result: LongExpressionResult) => dataStore.AssignLong(symbol, result.apply, info)
       case (LongSize, result: BigExpressionResult)  => dataStore.AssignLong(symbol, BigToLong(result.apply).apply, info)
@@ -127,14 +115,17 @@ class ExpressionCompiler(
         throw TreadleException(
           s"Error:assignment size mismatch ($size)${symbol.name} <= ($expressionSize)$expressionResult")
     }
-    addAssigner(assigner, triggerOption)
+
+    conditionalClockSymbol match {
+      case Some(clockSymbol) =>
+        val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
+        addAssigner(ClockBasedAssigner(assigner, clockSymbol, prevClockSymbol, dataStore, PositiveEdge))
+      case _ =>
+        addAssigner(assigner)
+    }
   }
 
-  def addAssigner(
-    assigner: Assigner,
-    triggerOption: Option[Symbol] = None
-  ): Unit = {
-
+  def addAssigner(assigner: Assigner): Unit = {
     val symbol = assigner.symbol
     externalModuleInputs.get(symbol) match {
       case Some(ExternalInputParams(instance, portName)) =>
@@ -142,7 +133,7 @@ class ExpressionCompiler(
         scheduler.addAssigner(symbol, dataStore.ExternalModuleInputAssigner(symbol, portName, instance, assigner))
       case _ =>
         // typical case
-        scheduler.addAssigner(symbol, assigner, triggerOption)
+        scheduler.addAssigner(symbol, assigner)
     }
   }
 
@@ -684,11 +675,15 @@ class ExpressionCompiler(
           makeAssigner(assignedSymbol, processExpression(con.expr), info = con.info)
 
           if(assignedSymbol.firrtlType == ClockType) {
-            getDrivingClock(con.expr).foreach { drivingClock =>
-              val downAssigner = dataStore.AssignInt(
-                assignedSymbol, makeGet(drivingClock).asInstanceOf[IntExpressionResult].apply, info = con.info)
-              scheduler.addUnassigner(drivingClock, downAssigner)
-            }
+            //
+            // If we are here then we need to add an assigner at the end of the cycle that records
+            // the clocks state in the clock's prev state
+            //
+            val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(assignedSymbol))
+            val prevClockAssigner = dataStore.AssignInt(
+              prevClockSymbol, makeGet(assignedSymbol).asInstanceOf[IntExpressionResult].apply, info = con.info
+            )
+            scheduler.endOfCycleAssigns += prevClockAssigner
           }
         }
 
@@ -719,11 +714,16 @@ class ExpressionCompiler(
                   }
                   if (port.tpe == ClockType) {
                     val clockSymbol = symbolTable(expand(instanceName + "." + port.name))
-                    val blackBoxCycler = BlackBoxCycler(instanceSymbol, implementation, clockSymbol, dataStore, info)
+                    val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
+
+                    val clockTransitionGetter = ClockTransitionGetter(clockSymbol, prevClockSymbol, dataStore)
+
+                    val blackBoxCycler = BlackBoxCycler(
+                      instanceSymbol, implementation, clockSymbol, clockTransitionGetter, info)
 
                     val drivingClockOption = symbolTable.findHighestClock(clockSymbol)
 
-                    scheduler.addAssigner(instanceSymbol, blackBoxCycler, triggerOption = drivingClockOption)
+                    scheduler.addAssigner(instanceSymbol, blackBoxCycler)
                   }
                   else if(port.direction == Input) {
                     val portSymbol = symbolTable(expand(instanceName + "." + port.name))
@@ -743,6 +743,17 @@ class ExpressionCompiler(
         val symbol = symbolTable(expand(name))
         logger.debug(s"declaration:DefNode:${symbol.name}:${expression.serialize}")
         makeAssigner(symbol, processExpression(expression), info = info)
+        if(symbol.firrtlType == ClockType) {
+          //
+          // If we are here then we need to add an assigner at the end of the cycle that records
+          // the clocks state in the clock's prev state
+          //
+          val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(symbol))
+          val prevClockAssigner = dataStore.AssignInt(
+            prevClockSymbol, makeGet(symbol).asInstanceOf[IntExpressionResult].apply, info
+          )
+          scheduler.endOfCycleAssigns += prevClockAssigner
+        }
 
       case DefWire(_, name, _) =>
         logger.debug(s"declaration:DefWire:$name")
@@ -776,16 +787,24 @@ class ExpressionCompiler(
                 throw TreadleException(s"Error: stop $stop has unknown condition type")
             }
 
-            val stopOp = StopOp(
-              symbol          = stopInfo.stopSymbol,
-              info            = info,
-              returnValue     = returnValue,
-              condition       = intExpression,
-              hasStopped      = symbolTable(StopOp.stopHappenedName),
-              dataStore       = dataStore
-            )
-            val drivingClockOption = getDrivingClock(clockExpression)
-            addAssigner(stopOp, triggerOption = drivingClockOption)
+            getDrivingClock(clockExpression) match {
+              case Some(clockSymbol) =>
+                val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
+
+                val clockTransitionGetter = ClockTransitionGetter(clockSymbol, prevClockSymbol, dataStore)
+                val stopOp = StopOp(
+                  symbol = stopInfo.stopSymbol,
+                  info = info,
+                  returnValue = returnValue,
+                  condition = intExpression,
+                  hasStopped = symbolTable(StopOp.stopHappenedName),
+                  dataStore = dataStore,
+                  clockTransitionGetter
+                )
+                addAssigner(stopOp)
+              case _ =>
+                throw TreadleException(s"Could not find symbol for Stop $stop")
+            }
 
           case _ =>
             throw TreadleException(s"Could not find symbol for Stop $stop")
@@ -803,15 +822,23 @@ class ExpressionCompiler(
                 throw TreadleException(s"Error: printf $printf has unknown condition type")
             }
 
-            val printOp = PrintfOp(
-              printInfo.printSymbol,
-              info, stringLiteral,
-              argExpressions.map { expression => processExpression(expression) },
-              intExpression,
-              dataStore
-            )
-            val drivingClockOption = getDrivingClock(clockExpression)
-            addAssigner(printOp, triggerOption = drivingClockOption)
+            getDrivingClock(clockExpression) match {
+              case Some(clockSymbol) =>
+                val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
+
+                val clockTransitionGetter = ClockTransitionGetter(clockSymbol, prevClockSymbol, dataStore)
+                val printOp = PrintfOp(
+                  printInfo.printSymbol,
+                  info, stringLiteral,
+                  argExpressions.map { expression => processExpression(expression) },
+                  clockTransitionGetter,
+                  intExpression
+                )
+                addAssigner(printOp)
+              case _ =>
+                throw TreadleException(s"Error: no clock found for Print $printf")
+            }
+
 
           case _ =>
             throw TreadleException(s"Could not find symbol for Print $printf")
@@ -851,7 +878,5 @@ class ExpressionCompiler(
     scheduler.registerClocks ++= FindRegisterClocks.run(module, circuit, symbolTable)
 
     processModule("", module, circuit)
-
-    scheduler.sortInputSensitiveAssigns()
   }
 }

--- a/src/main/scala/treadle/executable/PrintfOp.scala
+++ b/src/main/scala/treadle/executable/PrintfOp.scala
@@ -10,13 +10,13 @@ case class PrintfOp(
   info            : Info,
   string          : StringLit,
   args            : Seq[ExpressionResult],
-  condition       : IntExpressionResult,
-  dataStore       : DataStore
+  clockTransition : ClockTransitionGetter,
+  condition       : IntExpressionResult
 ) extends Assigner {
 
   def run: FuncUnit = {
     val conditionValue = condition.apply() > 0
-    if (conditionValue) {
+    if (conditionValue && clockTransition.isPosEdge) {
       val currentArgValues = args.map {
         case e: IntExpressionResult => e.apply()
         case e: LongExpressionResult => e.apply()

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -31,17 +31,17 @@ object SymbolAtDepth {
   * it shows all arguments of PrimOPs and should only show any symbols value once.
   * Muxes only show the expanded derivation of the branch taken
   * Display goes from top to bottom since it is usually the top value one wants
-  * to see rendered last.
+  * to see that is rendered last.
   *
   * @param dataStore        current state
   * @param symbolTable      the symbol table
   * @param expressionViews  expression information
   */
 class ExpressionViewRenderer(
-    dataStore       : DataStore,
-    symbolTable     : SymbolTable,
-    expressionViews : Map[Symbol, ExpressionView]
-
+  dataStore:          DataStore,
+  symbolTable:        SymbolTable,
+  expressionViews:    Map[Symbol, ExpressionView],
+  maxDependencyDepth: Int = 8
 ) {
 
   private def order(symbolAtDepth: SymbolAtDepth) = symbolAtDepth.displayDepth
@@ -131,11 +131,12 @@ class ExpressionViewRenderer(
       val argStrings = args.map {
         case symbol: Symbol =>
           if(! (
-            symbolTable.isRegister(symbol.name) ||
               symbolTable.inputPortsNames.contains(symbol.name) ||
               symbolsSeen.contains(symbol)
             )) {
-            symbolsToDo.enqueue(SymbolAtDepth(symbol, displayDepth + 1, dataTime, dataArrays))
+            if(displayDepth < maxDependencyDepth) {
+              symbolsToDo.enqueue(SymbolAtDepth(symbol, displayDepth + 1, dataTime, dataArrays))
+            }
           }
 
           val value = symbol.normalize(dataArrays.getValueAtIndex(symbol.dataSize, symbol.index))
@@ -191,14 +192,19 @@ class ExpressionViewRenderer(
           }
 
           if(symbolTable.isRegister(symbol.name)) {
-            val clockName = symbolTable.registerToClock(symbol).name
+            val clockSymbol = symbolTable.registerToClock(symbol)
+            val clockIndex  = clockSymbol.index
+            val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
+            val prevClockIndex = prevClockSymbol.index
 
-            dataStore.rollBackBufferManager.findEarlierBuffer(dataTime) match {
+            dataStore
+                    .rollBackBufferManager
+                    .findBufferBeforeClockTransition(dataTime, clockIndex, prevClockIndex) match {
 
               case Some(buffer) =>
                 builder ++= renderView(view, symbolAtDepth.displayDepth, buffer.time, buffer)
+
               case _ =>
-                builder ++= renderView(view, symbolAtDepth.displayDepth, dataTime, symbolAtDepth.dataArrays)
             }
           }
           else {

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -193,7 +193,7 @@ class ExpressionViewRenderer(
           if(symbolTable.isRegister(symbol.name)) {
             val clockName = symbolTable.registerToClock(symbol).name
 
-            dataStore.rollBackBufferManager.findEarlierBuffer(clockName, dataTime) match {
+            dataStore.rollBackBufferManager.findEarlierBuffer(dataTime) match {
 
               case Some(buffer) =>
                 builder ++= renderView(view, symbolAtDepth.displayDepth, buffer.time, buffer)

--- a/src/main/scala/treadle/executable/Scheduler.scala
+++ b/src/main/scala/treadle/executable/Scheduler.scala
@@ -167,9 +167,16 @@ class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
     * @return
     */
   def render(engine: ExecutionEngine): String = {
+    val expressionViewRenderer = new ExpressionViewRenderer(
+      engine.dataStore,
+      symbolTable,
+      engine.expressionViews,
+      maxDependencyDepth = 0
+    )
+
     def renderAssigner(assigner: Assigner): String = {
       val expression =
-        engine.expressionViewRenderer.render(assigner.symbol, engine.wallTime.currentTime, showValues = false)
+        expressionViewRenderer.render(assigner.symbol, engine.wallTime.currentTime, showValues = false)
 
       if(expression.isEmpty) {
         s"${assigner.symbol.name} :::"

--- a/src/main/scala/treadle/executable/Scheduler.scala
+++ b/src/main/scala/treadle/executable/Scheduler.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
 
   var combinationalAssigns : mutable.ArrayBuffer[Assigner] = new mutable.ArrayBuffer
-  val endOfCycleAssigns    : mutable.ArrayBuffer[Assigner] = new mutable.ArrayBuffer
+  val endOfCycleAssigns    : mutable.HashSet[Assigner] = new mutable.HashSet
 
   val registerClocks       : mutable.HashSet[Symbol] = new mutable.HashSet
 
@@ -49,6 +49,12 @@ class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
 
     toAssigner(symbol) = assigner
     combinationalAssigns += assigner
+  }
+
+  def addEndOfCycleAssigner(assigner: Assigner): Unit = {
+    if(! endOfCycleAssigns.exists(a => a.symbol == assigner.symbol)) {
+      endOfCycleAssigns += assigner
+    }
   }
 
   def hasAssigner(symbol: Symbol): Boolean = {

--- a/src/main/scala/treadle/executable/StopOp.scala
+++ b/src/main/scala/treadle/executable/StopOp.scala
@@ -10,12 +10,13 @@ case class StopOp(
   returnValue        : Int,
   condition          : IntExpressionResult,
   hasStopped         : Symbol,
-  dataStore          : DataStore
+  dataStore          : DataStore,
+  clockTransition    : ClockTransitionGetter
 ) extends Assigner {
 
   def run: FuncUnit = {
     val conditionValue = condition.apply() > 0
-    if (conditionValue) {
+    if (conditionValue && clockTransition.isPosEdge) {
       if (isVerbose) {
         println(s"clock ${symbol.name} has fired")
       }

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -270,8 +270,10 @@ object SymbolTable extends LazyLogging {
                 //
                 // we have found a clock on the LHS, create a previous value for it
                 val prevClockSymbolName = makePreviousValue(symbol)
-                val prevClockSymbol = Symbol(prevClockSymbolName, ClockType, WireKind, info = symbol.info)
-                addSymbol(prevClockSymbol)
+                if(! nameToSymbol.contains(prevClockSymbolName)) {
+                  val prevClockSymbol = Symbol(prevClockSymbolName, ClockType, WireKind, info = symbol.info)
+                  addSymbol(prevClockSymbol)
+                }
               }
 
               val references = expressionToReferences(con.expr)
@@ -352,6 +354,7 @@ object SymbolTable extends LazyLogging {
 
           addDependency(registerOut, expressionToReferences(clockExpression))
           addDependency(registerIn, expressionToReferences(resetExpression))
+          addDependency(registerIn, Set(registerOut))
 
           registerToClock(registerOut) = expressionToReferences(clockExpression).head
 

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -245,7 +245,7 @@ object SymbolTable extends LazyLogging {
       def createPrevClock(clockName: String, tpe: Type, info: Info): Unit = {
         val prevClockName = makePreviousValue(clockName)
 
-        val symbol = Symbol.apply(prevClockName, tpe, firrtl.NodeKind, slots = 0, info = info)
+        val symbol = Symbol.apply(prevClockName, tpe, firrtl.NodeKind, info = info)
 
         addSymbol(symbol)
       }

--- a/src/main/scala/treadle/executable/Transition.scala
+++ b/src/main/scala/treadle/executable/Transition.scala
@@ -43,14 +43,27 @@ case class ClockBasedAssigner(
 
   private val clockTransitionGetter = ClockTransitionGetter(clockSymbol, prevClockSymbol, dataStore)
 
-  override def run: FuncUnit = {
+  def runLean(): Unit = {
     if(clockTransitionGetter.transition == requiredTransition) {
       assigner.run()
     }
-    () => Unit
   }
+
+  def runFull(): Unit = {
+    if(clockTransitionGetter.transition == requiredTransition) {
+      assigner.run()
+    }
+    else if(isVerbose) {
+      println(
+        s"${assigner.symbol.name} <= register not updated" +
+            s" ${clockSymbol.name} state ${clockTransitionGetter.transition} not the required $requiredTransition")
+    }
+  }
+
+  var run: FuncUnit = runLean
 
   override def setLeanMode(isLean: Boolean): Unit = {
     assigner.setLeanMode(isLean)
+    run = if(isLean) runLean else runFull
   }
 }

--- a/src/main/scala/treadle/executable/Transition.scala
+++ b/src/main/scala/treadle/executable/Transition.scala
@@ -49,4 +49,8 @@ case class ClockBasedAssigner(
     }
     () => Unit
   }
+
+  override def setLeanMode(isLean: Boolean): Unit = {
+    assigner.setLeanMode(isLean)
+  }
 }

--- a/src/main/scala/treadle/executable/Transition.scala
+++ b/src/main/scala/treadle/executable/Transition.scala
@@ -1,11 +1,52 @@
 // See LICENSE for license details.
 
 package treadle.executable
+import firrtl.ir.Info
 
 trait Transition
-
-//TODO: (chick) incorporate NegativeEdge usage.
 
 case object PositiveEdge extends Transition
 case object NegativeEdge extends Transition
 case object NoTransition extends Transition
+
+/**
+  * Used internally by assigners that care about clock transitions
+  * @param clockSymbol the clock
+  * @param prevClockSymbol the previous state of the clock
+  * @param dataStore needed to get current and prev values
+  */
+case class ClockTransitionGetter(clockSymbol: Symbol, prevClockSymbol: Symbol, dataStore: DataStore) {
+  private val clockIndex = clockSymbol.index
+  private val prevClockIndex = prevClockSymbol.index
+  private val intData = dataStore.intData
+
+  def isPosEdge: Boolean = intData(clockIndex) > 0 && intData(prevClockIndex) == 0
+  def isNegEdge: Boolean = intData(clockIndex) == 0 && intData(prevClockIndex) > 0
+
+  def transition: Transition = {
+    if(isPosEdge) { PositiveEdge }
+    else if(isNegEdge) { NegativeEdge }
+    else { NoTransition }
+  }
+}
+
+case class ClockBasedAssigner(
+  assigner: Assigner,
+  clockSymbol: Symbol,
+  prevClockSymbol: Symbol,
+  dataStore: DataStore,
+  requiredTransition: Transition
+) extends Assigner {
+
+  override val symbol: Symbol = assigner.symbol
+  override val info: Info = assigner.info
+
+  private val clockTransitionGetter = ClockTransitionGetter(clockSymbol, prevClockSymbol, dataStore)
+
+  override def run: FuncUnit = {
+    if(clockTransitionGetter.transition == requiredTransition) {
+      assigner.run()
+    }
+    () => Unit
+  }
+}

--- a/src/main/scala/treadle/utils/RemoveTempWires.scala
+++ b/src/main/scala/treadle/utils/RemoveTempWires.scala
@@ -1,0 +1,133 @@
+// See LICENSE for license details.
+
+package treadle.utils
+
+// See LICENSE for license details.
+
+import firrtl.ir._
+import firrtl.{CircuitForm, CircuitState, LowForm, Parser, Transform, WRef, WSubField, WSubIndex}
+
+import scala.collection.mutable
+
+//scalastyle:off regex
+
+class RemoveTempWires extends Transform {
+  override def inputForm: CircuitForm = LowForm
+  override def outputForm: CircuitForm = LowForm
+
+  /**
+    * Foreach Module in a firrtl circuit
+    *   Find all the DefNodes with temp names and render their expression
+    *   Remove all the found dev nodes
+    *   recursively replace their references with their associated expression
+    * @param state to be altered
+    * @return
+    */
+  //scalastyle:off method.length cyclomatic.complexity
+  def execute(state: CircuitState): CircuitState = {
+
+    val c = state.circuit
+    /**
+      * removes all references to temp wires in module
+      * @param module the module to be altered
+      * @return
+      */
+    def removeTempWiresFromModule(module: Module): Module = {
+
+      val toRemove = new mutable.HashMap[String, Expression]()
+
+      /**
+        * Saves reference to the expression associated
+        * with a temp wire associated with a Node statement
+        * @param s statement to be checked
+        */
+      def collectTempExpressions(s: Statement): Unit = s match {
+        case block: Block =>
+          block.stmts.foreach { substatement =>
+            collectTempExpressions(substatement)
+          }
+
+        case node: DefNode =>
+          if (node.name.startsWith(RemoveTempWires.GenPrefix) || node.name.startsWith(RemoveTempWires.TempPrefix)) {
+
+            if (toRemove.contains(node.name)) {
+              println(s"Houston we have a problem, ${node.name} already marked for removal")
+            }
+            toRemove(node.name) = node.value
+            None
+          }
+        case _ => //do nothing
+      }
+
+      /**
+        * recursively find any references to temp wires in the expression and replace the
+        * references with the associated expression
+        * @param e expression to be altered
+        * @return
+        */
+      def removeGen(e: Expression): Expression = {
+        e match {
+          case wire: WRef =>
+            if ((wire.name.startsWith(RemoveTempWires.GenPrefix) ||
+                    wire.name.startsWith(RemoveTempWires.TempPrefix)) && toRemove.contains(wire.name)) {
+              val new_node = toRemove(wire.name)
+              removeGen(new_node)
+            } else {
+              wire
+            }
+          case wire: WSubField =>
+            if ((wire.name.startsWith(RemoveTempWires.GenPrefix) ||
+                    wire.name.startsWith(RemoveTempWires.TempPrefix)) && toRemove.contains(wire.name)) {
+              val new_node = toRemove(wire.name)
+              removeGen(new_node)
+            } else {
+              wire
+            }
+          case wire: WSubIndex =>
+            wire.mapExpr(removeGen)
+          case ee => ee.mapExpr(removeGen)
+        }
+      }
+
+      /**
+        * Removes node definition statements for temp wires
+        * @param s statement to be altered
+        * @return
+        */
+      def removeGenStatement(s: Statement): Option[Statement] = {
+        s match {
+          case block: Block =>
+            val result = Some(Block(block.stmts.flatMap { substatement =>
+              removeGenStatement(substatement)
+            }))
+            result
+          case node: DefNode =>
+            if (node.name.startsWith(RemoveTempWires.GenPrefix) || node.name.startsWith(RemoveTempWires.TempPrefix)) {
+              None
+            } else {
+              Some(node.mapExpr(removeGen))
+            }
+          case other: Statement =>
+            Some(other.mapExpr(removeGen))
+          case _ => Some(s) //do nothing
+        }
+      }
+
+      collectTempExpressions(module.body)
+      val moduleWithTempExpressionsRemmoved = removeGenStatement(module.body)
+      module.copy(body = moduleWithTempExpressionsRemmoved.get)
+    }
+
+    val newModules = c.modules.map {
+      case m: Module => removeTempWiresFromModule(m)
+      case otherMod => otherMod
+    }
+
+    state.copy(circuit = Circuit(c.info, newModules, c.main))
+  }
+}
+
+object RemoveTempWires  {
+  val GenPrefix = "_GEN_"
+  val TempPrefix = "_T_"
+}

--- a/src/test/scala/treadle/ClockedManuallySpec.scala
+++ b/src/test/scala/treadle/ClockedManuallySpec.scala
@@ -43,6 +43,10 @@ class ClockedManuallySpec extends FreeSpec with Matchers {
         vcdShowUnderscored = true,
         writeVCD = true
       )
+      commonOptions = commonOptions.copy(
+        targetDirName = "test_run_dir/manually_clocked_pos",
+        topName = "manually_clocked_pos",
+      )
     }
 
     val tester = new TreadleTester(input, optionsManager)
@@ -89,8 +93,8 @@ class ClockedManuallySpec extends FreeSpec with Matchers {
         writeVCD = true
       )
       commonOptions = commonOptions.copy(
-        targetDirName = "test_run_dir/manually_clocked/clock_up",
-        topName = "clock_up"
+        targetDirName = "test_run_dir/manually_clocked_neg",
+        topName = "neg_reg"
       )
     }
 
@@ -103,7 +107,7 @@ class ClockedManuallySpec extends FreeSpec with Matchers {
     tester.poke("reset", 0)
 
     tester.expect("out_direct", 1)
-    tester.expect("out_from_reg", 1)
+    tester.expect("out_from_reg", 0)
     tester.expect("inverted_clock", 0)
 
     tester.advanceTime(10)
@@ -112,12 +116,16 @@ class ClockedManuallySpec extends FreeSpec with Matchers {
     tester.poke("clock", 0)
 
     tester.expect("out_direct", 2)
-    tester.expect("out_from_reg", 1)
+    tester.expect("out_from_reg", 0)
     tester.expect("inverted_clock", 1)
 
     tester.advanceTime(10)
 
-    tester.poke("in1", 1)
+    tester.poke("clock", 1)
+
+    tester.expect("out_direct", 2)
+    tester.expect("out_from_reg", 2)
+    tester.expect("inverted_clock", 0)
 
     tester.report()
   }

--- a/src/test/scala/treadle/GCDTester.scala
+++ b/src/test/scala/treadle/GCDTester.scala
@@ -147,7 +147,7 @@ class GCDTester extends FlatSpec with Matchers {
     }
 
     val values =
-      for {x <- 1 to 1000
+      for {x <- 1 to 100
            y <- 1 to 100
       } yield (x, y, computeGcd(x, y)._1)
 

--- a/src/test/scala/treadle/SnapshotSpec.scala
+++ b/src/test/scala/treadle/SnapshotSpec.scala
@@ -62,8 +62,11 @@ class SnapshotSpec extends FreeSpec with Matchers {
     t.step()
 
     val snapshot1 = t.engine.dataStore.serialize
+
+    println(s"snapshot0\n$snapshot0")
+    println(s"snapshot1\n$snapshot1")
+
     snapshot1.contains(""""numberOfBuffers":4,""") should be (true)
-    snapshot1.contains(""""clockName":"clock",""") should be (true)
 
     println(s"snapshot0\n$snapshot0")
     println(s"snapshot1\n$snapshot1")

--- a/src/test/scala/treadle/VecSpec.scala
+++ b/src/test/scala/treadle/VecSpec.scala
@@ -2,7 +2,6 @@
 
 package treadle
 
-import firrtl.CommonOptions
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.StopException
 
@@ -36,7 +35,8 @@ class VecSpec extends FreeSpec with Matchers {
       treadleOptions = treadleOptions.copy(
         writeVCD = false,
         setVerbose = false,
-        showFirrtlAtLoad = false
+        showFirrtlAtLoad = false,
+        rollbackBuffers = 20
       )
       commonOptions = commonOptions.copy(
         targetDirName = "test_run_dir/vec_spec1",
@@ -47,27 +47,35 @@ class VecSpec extends FreeSpec with Matchers {
     val tester = new TreadleTester(input, optionsManager)
 
     def show(): Unit = {
-      println("")
-      for(name <- Seq("shifter_3", "shifter_2", "shifter_1", "shifter_0")) {
+      println("Rendering register assignments")
+      for(name <- Seq.tabulate(1) { i => s"shifter_$i" }) {
         println(s"${tester.engine.renderComputation(name)}")
       }
     }
 
+    def testRegisterValues(value0: BigInt, value1: BigInt, value2: BigInt, value3: BigInt) {
+      tester.expect("shifter_0", value0)
+      tester.expect("shifter_1", value1)
+      tester.expect("shifter_2", value2)
+      tester.expect("shifter_3", value3)
+    }
+
+    tester.step()
+    testRegisterValues(0, 0, 0, 0)
     tester.step()
     show()
+    testRegisterValues(0, 0, 0, 1)
     tester.step()
+    testRegisterValues(0, 0, 1, 2)
+    tester.step()
+    testRegisterValues(0, 1, 2, 3)
+    tester.step()
+    testRegisterValues(1, 2, 3, 4)
+    tester.step()
+    testRegisterValues(2, 3, 4, 5)
     show()
-    tester.step()
-    show()
-    tester.step()
-    show()
-    tester.step()
-    show()
-    tester.step()
-    show()
-    tester.step()
-    show()
-    tester.step()
+
+    tester.report()
   }
 
   "VecSpec should pass a basic test" in {

--- a/src/test/scala/treadle/VecSpec.scala
+++ b/src/test/scala/treadle/VecSpec.scala
@@ -38,6 +38,10 @@ class VecSpec extends FreeSpec with Matchers {
         setVerbose = false,
         showFirrtlAtLoad = false
       )
+      commonOptions = commonOptions.copy(
+        targetDirName = "test_run_dir/vec_spec1",
+        topName = "vec_spec"
+      )
     }
 
     val tester = new TreadleTester(input, optionsManager)

--- a/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
@@ -42,7 +42,7 @@ class BlackBoxWithState extends FreeSpec with Matchers {
 
     val manager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
-        setVerbose = true,
+        setVerbose = false,
         writeVCD = false,
         symbolsToWatch = Seq("io_data"),
         blackBoxFactories = Seq(new AccumBlackBoxFactory),

--- a/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
@@ -42,7 +42,7 @@ class BlackBoxWithState extends FreeSpec with Matchers {
 
     val manager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
-        setVerbose = false,
+        setVerbose = true,
         writeVCD = false,
         symbolsToWatch = Seq("io_data"),
         blackBoxFactories = Seq(new AccumBlackBoxFactory),
@@ -75,6 +75,9 @@ class AccumulatorBlackBox(val name: String) extends ScalaBlackBox {
   var ns : BigInt = 0
   var ps : BigInt = 0
   var isInReset: Boolean = false
+
+  override def inputChanged(name: String, value: BigInt): Unit = {
+  }
 
   def outputDependencies(outputName: String): Seq[String] = {
     outputName match {

--- a/src/test/scala/treadle/chronometry/ClockCrossingSpec.scala
+++ b/src/test/scala/treadle/chronometry/ClockCrossingSpec.scala
@@ -44,7 +44,7 @@ class ClockCrossingSpec extends FreeSpec with Matchers {
     Driver.execute(firrtlOptionsManager) match {
       case FirrtlExecutionSuccess(_, highFirrtl) =>
         val optionsManager = new TreadleOptionsManager {
-          commonOptions = commonOptions.copy(targetDirName = "test_run_dir/clock_crossing")
+          commonOptions = commonOptions.copy(targetDirName = "test_run_dir/clock_crossing", topName = "clock_crossing")
           treadleOptions = treadleOptions.copy(
             setVerbose = false, writeVCD = false, callResetAtStartUp = false,
             showFirrtlAtLoad = false,

--- a/src/test/scala/treadle/chronometry/PrintfOnDerivedClockSpec.scala
+++ b/src/test/scala/treadle/chronometry/PrintfOnDerivedClockSpec.scala
@@ -62,6 +62,7 @@ class PrintfOnDerivedClockSpec extends FreeSpec with Matchers {
       tester.finish
     }
 
+    println(output.toString)
     // printf will be in output twice once for each up transition of io_in, which drives the derived clock
     output.toString.split("\n").count( line => line.contains("SPI spi.sck=")) should be (2)
   }

--- a/src/test/scala/treadle/chronometry/PrintfOnDerivedClockSpec.scala
+++ b/src/test/scala/treadle/chronometry/PrintfOnDerivedClockSpec.scala
@@ -62,7 +62,6 @@ class PrintfOnDerivedClockSpec extends FreeSpec with Matchers {
       tester.finish
     }
 
-    println(output.toString)
     // printf will be in output twice once for each up transition of io_in, which drives the derived clock
     output.toString.split("\n").count( line => line.contains("SPI spi.sck=")) should be (2)
   }

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -46,7 +46,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
 
     val keyToDependent = symbolTable.childrenOf
 
-    keyToDependent.reachableFrom(symbolTable("clock")).size should be (2)
+    keyToDependent.reachableFrom(symbolTable("clock")).size should be (3)
 
     symbolTable.registerNames.toList.sorted.foreach { key =>
       val dependents = symbolTable.childrenOf.reachableFrom(symbolTable(key))
@@ -133,7 +133,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
 
     val childrenOf = symbolTable.childrenOf
 
-    childrenOf.reachableFrom(symbolTable("clock")).size should be (2)
+    childrenOf.reachableFrom(symbolTable("clock")).size should be (3)
 
     childrenOf.reachableFrom(symbolTable("io_in1")) should not contain symbolTable("io_out1")
 
@@ -190,7 +190,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
 
     val childrenOf = symbolTable.childrenOf
 
-    childrenOf.reachableFrom(symbolTable("clock")).size should be (2)
+    childrenOf.reachableFrom(symbolTable("clock")).size should be (3)
 
     childrenOf.reachableFrom(symbolTable("io_in1")) should contain (symbolTable("io_out1"))
     childrenOf.reachableFrom(symbolTable("io_in2")) should not contain symbolTable("io_out1")

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -46,6 +46,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
 
     val keyToDependent = symbolTable.childrenOf
 
+    // b3, b3/in, and io_out2 depend on clock
     keyToDependent.reachableFrom(symbolTable("clock")).size should be (3)
 
     symbolTable.registerNames.toList.sorted.foreach { key =>
@@ -133,6 +134,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
 
     val childrenOf = symbolTable.childrenOf
 
+    // a3, a3/in and io_out1 depend on clock
     childrenOf.reachableFrom(symbolTable("clock")).size should be (3)
 
     childrenOf.reachableFrom(symbolTable("io_in1")) should not contain symbolTable("io_out1")

--- a/src/test/scala/treadle/vcd/VCDSpec.scala
+++ b/src/test/scala/treadle/vcd/VCDSpec.scala
@@ -277,7 +277,7 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
     val replayTester = new VcdReplayTester(replayManager)
     replayTester.run()
 
-    replayTester.testSuccesses should be (7)
+    replayTester.testSuccesses should be (8)
     replayTester.testFailures should be (0)
   }
 }


### PR DESCRIPTION
This is a large refactor of the execution engine of treadle that accomplishes several tasks
- Makes multi-clock handling work properly even across clock inversions and asClocks
- Fixes printf breaking due to incorrect dependency relations, args might not be calculated before use
- Stop condition could have problem with enable.
- Overall execution is much simpler
- Seems to fix [/freechipsproject/chisel3/issues/993](/freechipsproject/chisel3/issues/993)

It has one major regression issue
- It is 60% of the speed of the current master
- this is due to full circuit evaluation on clock low transition.