### PR TITLE
Avoid 2.11 compilation errors with trailing commas.

### DIFF
--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -266,7 +266,7 @@ class ExecutionEngine(
   // scalastyle:off cyclomatic.complexity method.length
   def setIntValue(
     symbol: Symbol,
-    value: Int,
+    value: Int
   ): Int = {
 
     inputsChanged = true

--- a/src/test/scala/treadle/ClockedManuallySpec.scala
+++ b/src/test/scala/treadle/ClockedManuallySpec.scala
@@ -45,7 +45,7 @@ class ClockedManuallySpec extends FreeSpec with Matchers {
       )
       commonOptions = commonOptions.copy(
         targetDirName = "test_run_dir/manually_clocked_pos",
-        topName = "manually_clocked_pos",
+        topName = "manually_clocked_pos"
       )
     }
 


### PR DESCRIPTION
We still support Scala 2.11 which doesn't allow trailing commas.
