### PR TITLE
Printfs were not printing register values correctly

### DIFF
--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -7,7 +7,7 @@ import firrtl.ir.{Circuit, NoInfo}
 import firrtl.transforms.DontCheckCombLoopsAnnotation
 import treadle._
 import treadle.chronometry.{Timer, UTC}
-import treadle.utils.{Render, ToLoFirrtl}
+import treadle.utils.{AugmentPrintf, Render, ToLoFirrtl}
 import treadle.vcd.VCD
 
 import scala.collection.mutable
@@ -458,7 +458,7 @@ object ExecutionEngine {
     val blackBoxFactories: Seq[ScalaBlackBoxFactory] = treadleOptions.blackBoxFactories
     val timer = new Timer
 
-    val loweredAst: Circuit = if(treadleOptions.lowCompileAtLoad) {
+    val oldLoweredAst: Circuit = if(treadleOptions.lowCompileAtLoad) {
       if(treadleOptions.allowCycles) {
         optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(
           annotations = optionsManager.firrtlOptions.annotations :+ DontCheckCombLoopsAnnotation
@@ -468,6 +468,8 @@ object ExecutionEngine {
     } else {
       ast
     }
+
+    val loweredAst: Circuit = AugmentPrintf(oldLoweredAst)
 
     if(treadleOptions.showFirrtlAtLoad) {
       println("LoFirrtl" + "=" * 120)

--- a/src/main/scala/treadle/executable/PrintfOp.scala
+++ b/src/main/scala/treadle/executable/PrintfOp.scala
@@ -14,6 +14,8 @@ case class PrintfOp(
   condition       : IntExpressionResult
 ) extends Assigner {
 
+  private val formatString = string.escape
+
   def run: FuncUnit = {
     val conditionValue = condition.apply() > 0
     if (conditionValue && clockTransition.isPosEdge) {
@@ -22,7 +24,6 @@ case class PrintfOp(
         case e: LongExpressionResult => e.apply()
         case e: BigExpressionResult => e.apply()
       }
-      val formatString = string.escape
       val instantiatedString = executeVerilogPrint(formatString, currentArgValues)
       print(instantiatedString.drop(1).dropRight(1))
     }

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -191,7 +191,8 @@ class ExpressionViewRenderer(
             builder ++= " <= "
           }
 
-          if(symbolTable.isRegister(symbol.name)) {
+          // If not showing values then just don't worry about previous rollback buffer
+          if(symbolTable.isRegister(symbol.name) && showValues) {
             val clockSymbol = symbolTable.registerToClock(symbol)
             val clockIndex  = clockSymbol.index
             val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -566,9 +566,6 @@ object SymbolTable extends LazyLogging {
       else if(symbol.name.startsWith("/stop")) {
         Int.MaxValue - 1
       }
-      else if(symbol.name.startsWith("/print")) {
-        Int.MaxValue - 2
-      }
       else {
         index
       }

--- a/src/main/scala/treadle/utils/AugmentPrintf.scala
+++ b/src/main/scala/treadle/utils/AugmentPrintf.scala
@@ -1,0 +1,49 @@
+// See LICENSE for license details.
+
+package treadle.utils
+
+import firrtl.ir.Circuit
+
+import scala.collection.mutable
+
+/**
+  * Printf statements that print registers will show wrong values
+  * unless this pass adds a delay for each register
+  */
+object AugmentPrintf {
+  def apply(circuit: Circuit): Circuit = {
+    import firrtl.ir._
+    import firrtl._
+    def insert(newStmts: mutable.ArrayBuffer[Statement], namespace: Namespace, info: Info, clockExpression: Expression)
+            (a: Expression): Expression = {
+      if (Utils.kind(a) == RegKind) {
+        val newName = namespace.newTemp
+        val wref = WRef(newName, a.tpe, NodeKind, MALE)
+        newStmts += DefRegister(info, newName, a.tpe, clockExpression, UIntLiteral(0), UIntLiteral(0))
+        newStmts += Connect(info, wref, a)
+        wref
+      } else {
+        a
+      }
+    }
+
+    def fixPrintsStmt(namespace: firrtl.Namespace)
+            (s: Statement): Statement = s.mapStmt(fixPrintsStmt(namespace)) match {
+      case s: Stop =>
+        val newStmts = mutable.ArrayBuffer[Statement]()
+        val newStop = s.mapExpr(insert(newStmts, namespace, s.info, s.clk))
+        Block(newStmts :+ newStop)
+      case p: Print =>
+        val newStmts = mutable.ArrayBuffer[Statement]()
+        val newPrint = p.mapExpr(insert(newStmts, namespace, p.info, p.clk))
+        Block(newStmts :+ newPrint)
+      case other => other
+    }
+
+    circuit.mapModule { m =>
+      val ns = Namespace(m)
+      m.mapStmt(fixPrintsStmt(ns))
+    }
+  }
+
+}

--- a/src/test/scala/treadle/ClockedManuallySpec.scala
+++ b/src/test/scala/treadle/ClockedManuallySpec.scala
@@ -88,7 +88,7 @@ class ClockedManuallySpec extends FreeSpec with Matchers {
 
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
-        setVerbose = true,
+        setVerbose = false,
         vcdShowUnderscored = true,
         writeVCD = true
       )

--- a/src/test/scala/treadle/ExpressionRenderSpec.scala
+++ b/src/test/scala/treadle/ExpressionRenderSpec.scala
@@ -87,7 +87,7 @@ class ExpressionRenderSpec extends FreeSpec with Matchers {
       treadleOptions = treadleOptions.copy(
         writeVCD = false,
         vcdShowUnderscored = false,
-        setVerbose = true,
+        setVerbose = false,
         showFirrtlAtLoad = false,
         rollbackBuffers = 10,
         symbolsToWatch = Seq()

--- a/src/test/scala/treadle/blackboxes/AsyncResetRegSpec.scala
+++ b/src/test/scala/treadle/blackboxes/AsyncResetRegSpec.scala
@@ -94,7 +94,7 @@ class AsyncResetRegSpec extends FreeSpec with Matchers {
       treadleOptions = treadleOptions.copy(
         blackBoxFactories = Seq(new AsyncResetBlackBoxFactory),
         callResetAtStartUp = false,
-        setVerbose = true,
+        setVerbose = false,
         showFirrtlAtLoad = true
       )
     }
@@ -158,7 +158,7 @@ class AsyncResetRegSpec extends FreeSpec with Matchers {
       treadleOptions = treadleOptions.copy(
         blackBoxFactories = Seq(new AsyncResetBlackBoxFactory),
         callResetAtStartUp = false,
-        setVerbose = true
+        setVerbose = false
       )
     }
     val tester = TreadleTester(input, manager)


### PR DESCRIPTION
- Add AugmentPrintf to generate temporary registers between registers
- call that pass at beginning of engine creation
- make printf cache its parsed format string
- fixed display of assigners shown at startup when setVerbose is on
  - discovered during debugging
  - showing without values should not require rollback buffers
- remove hardcoded sorting of printf to the end of assigner list
- fixed some leftover verbose settings in tests
- add and augment tests of printf