### PR TITLE
Set default rollbackBuffers to 0 to improve memory performance

### DIFF
--- a/src/main/scala/treadle/Driver.scala
+++ b/src/main/scala/treadle/Driver.scala
@@ -18,7 +18,7 @@ case class TreadleOptions(
                            showFirrtlAtLoad  : Boolean              = false,
                            lowCompileAtLoad  : Boolean              = true,
                            validIfIsRandom   : Boolean              = false,
-                           rollbackBuffers   : Int                  = 10,
+                           rollbackBuffers   : Int                  = 0,
                            clockInfo         : Seq[ClockInfo]       = Seq.empty,
                            resetName         : String               = "reset",
                            callResetAtStartUp: Boolean              = false,

--- a/src/test/scala/treadle/primops/AndOrXor.scala
+++ b/src/test/scala/treadle/primops/AndOrXor.scala
@@ -188,4 +188,25 @@ class AndOrXor extends FreeSpec with Matchers {
       AndInts(() => a, () => b, bitWidth).apply() should be(expected)
     }
   }
+
+  "(7.U.asSInt & true.B.asSInt).asUInt => 7.U" in {
+    val input =
+      """
+        |circuit Check :
+        |  module Check :
+        |    input a : UInt<4>
+        |    input b : UInt<1>
+        |    output c : UInt<4>
+        |    c <= asUInt(and(asSInt(a), asSInt(b)))
+        |
+      """.stripMargin
+
+    val tester = new TreadleTester(input)
+
+    tester.poke("a", 7)
+    tester.poke("b", 1)
+    tester.expect("c", 7)
+
+  }
+
 }

--- a/src/test/scala/treadle/primops/AndOrXor.scala
+++ b/src/test/scala/treadle/primops/AndOrXor.scala
@@ -188,25 +188,4 @@ class AndOrXor extends FreeSpec with Matchers {
       AndInts(() => a, () => b, bitWidth).apply() should be(expected)
     }
   }
-
-  "(7.U.asSInt & true.B.asSInt).asUInt => 7.U" in {
-    val input =
-      """
-        |circuit Check :
-        |  module Check :
-        |    input a : UInt<4>
-        |    input b : UInt<1>
-        |    output c : UInt<4>
-        |    c <= asUInt(and(asSInt(a), asSInt(b)))
-        |
-      """.stripMargin
-
-    val tester = new TreadleTester(input)
-
-    tester.poke("a", 7)
-    tester.poke("b", 1)
-    tester.expect("c", 7)
-
-  }
-
 }


### PR DESCRIPTION
- Changed default value to 0
- Added another feature to Regression that demonstrates above change
- Added small test to answer question about sign extension of SInt combined with And