### PR TITLE
Fix for problem with black boxes with state interconnected

### DIFF
--- a/src/main/scala/treadle/ScalaBlackBox.scala
+++ b/src/main/scala/treadle/ScalaBlackBox.scala
@@ -27,7 +27,9 @@ trait ScalaBlackBox {
 
   /**
     * getOutput is called to determine the value for the named output at the
-    * current state of the system.
+    * current state of the system. The proper way to do this is to not use the inputValues.
+    * Instead use[[inputChanged]] to supply a black box with its inputs.
+    *
     * @param inputValues This is a list of BigInt values that are in the same order
     *                    as the outputDependencies lists them
     * @param tpe         The concrete type of this output
@@ -50,6 +52,18 @@ trait ScalaBlackBox {
     * @return
     */
   def outputDependencies(outputName: String): Seq[String]
+
+  /**
+    * returns a list of dependencies between ports.
+    * @note There is one bit of hand-waving magic to make black boxes work when they have internal state.
+    * In order to satisfy the single pass assignment to every wire, black boxes with state must specify that
+    * their inputs depend on their outputs, in order to get the correct topological sort. See the AsyncResetBlackBox
+    * test to see an example of how this was done.
+    * @return
+    */
+  def getDependencies: Seq[(String, Set[String])] = {
+    Seq.empty
+  }
 
   /**
     * Add any parameters to the black box implementation

--- a/src/test/scala/treadle/RegisterSpec.scala
+++ b/src/test/scala/treadle/RegisterSpec.scala
@@ -376,8 +376,7 @@ class RegisterSpec extends FlatSpec with Matchers {
         lowCompileAtLoad = true
       )
       firrtlOptions = firrtlOptions.copy(
-        noDCE = true,
-
+        noDCE = true
       )
     }
     val tester = TreadleTester(input, manager)

--- a/src/test/scala/treadle/asyncreset/AsyncResetBlackBox.scala
+++ b/src/test/scala/treadle/asyncreset/AsyncResetBlackBox.scala
@@ -42,7 +42,21 @@ class AsyncResetReg(val instanceName: String) extends ScalaBlackBox {
   }
 
   override def outputDependencies(outputName: String): Seq[String] = {
-    Seq("rst", "clk", "io_d", "io_en")
+    Seq.empty
+  }
+
+  /**
+    * Important note: The dependency of io_d on io_q makes this test work by making sure
+    * that the assignments are sorted correctly topologically.
+    * They mirror a similar pattern used on registers, necessary for treadle to be able
+    * to update the circuit in a single pass.
+    * @return
+    */
+  override def getDependencies: Seq[(String, Set[String])] = {
+    Seq(
+      "io_d" -> Set("io_q"),
+      "io_q" -> Set("rst", "clk")
+    )
   }
 
   override def setParams(params: Seq[Param]): Unit = {


### PR DESCRIPTION
- Extend ScalaBlackBox API to add ability to report more dependencies
- SymbolTable uses new method to build better dependency graph
- Added tests for mutually connected registers
- Added similar tests for mutually connected ASyncReset black box registers