### PR TITLE
Vcd output broken when poking same wire without clock step. Issue #90

### DIFF
--- a/src/main/scala/treadle/vcd/VCD.scala
+++ b/src/main/scala/treadle/vcd/VCD.scala
@@ -616,6 +616,7 @@ case class VCD(
       }
       else {
         val changeSet = valuesAtTime.getOrElseUpdate(timeStamp, new mutable.HashSet[Change])
+        changeSet -= change // This removes a previous value for the wire associated with this change, if there is one.
         changeSet += change
       }
     }
@@ -714,6 +715,8 @@ case class Wire(name: String, id: String, width: Int, path: Array[String] = Arra
 
 /**
   * holds the information about
+  * hashCode and equals are overriden so that sets of changes can only
+  * hold one value for a specific wire
  *
   * @param wire wire who's status is being monitored
   * @param value the value this wire now has
@@ -731,6 +734,23 @@ case class Change(wire: Wire, value: BigInt) {
   }
   def serializeUninitialized: String = {
     s"b${"x" * wire.width} ${wire.id}"
+  }
+
+  override def toString: String = {
+    s"Change(${wire.fullName}(${wire.id}), newValue=$value)"
+  }
+
+  override def hashCode(): Int = {
+    wire.id.hashCode
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case Change(w, _) =>
+        wire.id == w.id
+      case _ =>
+        false
+    }
   }
 }
 

--- a/src/main/scala/treadle/vcd/VCD.scala
+++ b/src/main/scala/treadle/vcd/VCD.scala
@@ -714,11 +714,11 @@ case class Wire(name: String, id: String, width: Int, path: Array[String] = Arra
 }
 
 /**
-  * holds the information about
-  * hashCode and equals are overriden so that sets of changes can only
-  * hold one value for a specific wire
+  * A Record of a change to a wire.
+  *
+  * @note hashCode and equals are overridden so that sets of Change can only hold one value for a specific wire
  *
-  * @param wire wire who's status is being monitored
+  * @param wire  wire that was changed
   * @param value the value this wire now has
   */
 case class Change(wire: Wire, value: BigInt) {

--- a/src/test/scala/treadle/vcd/VCDSpec.scala
+++ b/src/test/scala/treadle/vcd/VCDSpec.scala
@@ -9,6 +9,8 @@ import java.io.File
 
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.util.Random
+
 // scalastyle:off magic.number
 class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
   private def getVcd = {
@@ -28,6 +30,26 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
       ids += id
 
       id.forall { c => c.toInt >= 33 && c.toInt <= 126 } should be(true)
+    }
+  }
+
+  it should "only remember the last change added" in {
+    val vcd = getVcd
+    val rand = new Random()
+    var lastValue = 0
+
+    vcd.setTime(100)
+
+    for(_ <- 0 to 10) {
+      for (i <- 0 to 10) {
+        lastValue = rand.nextInt()
+        vcd.wireChanged("testWire1", lastValue)
+      }
+
+      vcd.valuesAtTime(vcd.timeStamp).size should be (1)
+      vcd.valuesAtTime(vcd.timeStamp).head.value should be(lastValue)
+
+      vcd.incrementTime(10)
     }
   }
 


### PR DESCRIPTION
- Make it so values recorded at given time retains only last value
- Change hashCode and equals of Change class to be based on wire id
- Remove change for given wire before adding new one
- Add a test for last value kept during add behavior
- Fixes Issue #90 Incorrect Waveform Output