### PR TITLE
Add ability to force a wire.

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -206,6 +206,30 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = TreadleTest
     case _ => false
   }
 
+  def forceValue(name: String, value: BigInt): Unit = {
+    engine.symbolTable.get(name) match {
+      case Some(symbol) =>
+        symbol.forcedValue = Some(value)
+        if(engine.symbolTable.isRegister(name)) {
+          engine.setValue(name, value, registerPoke = true)
+        }
+        engine.inputsChanged = true
+      case _ => println(s"Error: forceValue($name, $value) $name not found in symbol table")
+    }
+    if(engine.dataStore.leanMode) {
+      engine.scheduler.setLeanMode(false)
+    }
+  }
+
+  def clearForceValue(name: String): Unit = {
+    engine.symbolTable.get(name) match {
+      case Some(symbol) =>
+        symbol.forcedValue = None
+        engine.inputsChanged = true
+      case _ => println(s"Error: clearForceValue($name) $name not found in symbol table")
+    }
+  }
+
   /**
     * Pokes value to the port referenced by string
     * Warning: pokes to components other than input ports is currently

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -167,7 +167,7 @@ extends HasDataArrays {
     }
 
     def runFull(): Unit = {
-      val value = expression()
+      val value = if( symbol.forcedValue.isDefined) { symbol.forcedValue.get.toInt } else { expression() }
       intData(index) = value
       runPlugins(symbol)
     }
@@ -206,7 +206,8 @@ extends HasDataArrays {
     }
 
     def runFull(): Unit = {
-      val value = expression()
+      val value = if( symbol.forcedValue.isDefined) { symbol.forcedValue.get.toLong } else { expression() }
+
       longData(index) = value
       runPlugins(symbol)
     }
@@ -232,7 +233,8 @@ extends HasDataArrays {
       bigData(index) = expression()
     }
     def runFull(): Unit = {
-      val value = expression()
+      val value = if( symbol.forcedValue.isDefined) { symbol.forcedValue.get } else { expression() }
+
       bigData(index) = value
       runPlugins(symbol)
     }
@@ -295,7 +297,8 @@ extends HasDataArrays {
 
     def runFull(): Unit = {
       if(enable() > 0) {
-        val value = expression()
+        val value = if( symbol.forcedValue.isDefined) { symbol.forcedValue.get.toInt } else { expression() }
+
         val memoryIndex = getMemoryIndex.apply()
         intData(index + (memoryIndex % memorySymbol.slots)) = value
         runPlugins(memorySymbol, memoryIndex)
@@ -326,7 +329,8 @@ extends HasDataArrays {
 
     def runFull(): Unit = {
       if(enable() > 0) {
-        val value = expression()
+        val value = if( symbol.forcedValue.isDefined) { symbol.forcedValue.get.toLong } else { expression() }
+
         val memoryIndex = getMemoryIndex.apply()
         longData(index + (memoryIndex % memorySymbol.slots)) = value
         runPlugins(memorySymbol, memoryIndex)
@@ -357,7 +361,8 @@ extends HasDataArrays {
 
     def runFull(): Unit = {
       if(enable() > 0) {
-        val value = expression()
+        val value = if( symbol.forcedValue.isDefined) { symbol.forcedValue.get } else { expression() }
+
         val memoryIndex = getMemoryIndex.apply()
         bigData(index + (memoryIndex % memorySymbol.slots)) = value
         runPlugins(memorySymbol, memoryIndex)

--- a/src/main/scala/treadle/executable/DataStorePlugIn.scala
+++ b/src/main/scala/treadle/executable/DataStorePlugIn.scala
@@ -37,12 +37,24 @@ class ReportAssignments(val executionEngine: ExecutionEngine) extends DataStoreP
 
   def run(symbol: Symbol, offset: Int = -1): Unit = {
     if(offset == -1) {
-      val showValue = symbol.normalize(dataStore(symbol))
-      println(s"${symbol.name} <= $showValue h${showValue.toString(16)}")
+      val valueMessage = if(symbol.forcedValue.isDefined) {
+        s" FORCED(${symbol.forcedValue.get}"
+      }
+      else {
+        val showValue = symbol.normalize(dataStore(symbol))
+        s"$showValue h${showValue.toString(16)}"
+      }
+      println(s"${symbol.name} <=$valueMessage")
     }
     else {
-      val showValue = symbol.normalize(dataStore(symbol, offset))
-      println(s"${symbol.name}($offset) <= $showValue")
+      val valueMessage = if(symbol.forcedValue.isDefined) {
+        s" FORCED(${symbol.forcedValue.get}"
+      }
+      else {
+        val showValue = symbol.normalize(dataStore(symbol, offset))
+        s"$showValue h${showValue.toString(16)}"
+      }
+      println(s"${symbol.name}($offset) <= $valueMessage")
     }
   }
 }
@@ -59,6 +71,9 @@ class RenderComputations(
 
   def run(symbol: Symbol, offset: Int = -1): Unit = {
     if(symbolsToWatch.contains(symbol)) {
+      if(symbol.forcedValue.isDefined) {
+        print(s"FORCED(${symbol.forcedValue.get} would have been: ")
+      }
       println(executionEngine.renderComputation(symbol.name))
     }
   }

--- a/src/main/scala/treadle/executable/Symbol.scala
+++ b/src/main/scala/treadle/executable/Symbol.scala
@@ -22,6 +22,8 @@ case class Symbol(
 
   val masks:          BitMasksBigs = BitMasks.getBitMasksBigs(bitWidth)
 
+  var forcedValue: Option[BigInt] = None
+
   def makeUInt(a: BigInt, bitWidth: Int): BigInt = {
     val b = a & masks.allBitsMask
     b

--- a/src/test/scala/treadle/ForceValueSpec.scala
+++ b/src/test/scala/treadle/ForceValueSpec.scala
@@ -1,0 +1,122 @@
+// See LICENSE for license details.
+
+package treadle
+
+import org.scalatest.{FreeSpec, Matchers}
+
+//scalastyle:off magic.number
+class ForceValueSpec extends FreeSpec with Matchers {
+  val simpleCircuit: String =
+    s"""
+       |circuit SimpleCircuit :
+       |  module SimpleCircuit :
+       |    input clock : Clock
+       |    input reset : UInt<1>
+       |    input in_a : UInt<16>
+       |    input in_b : UInt<16>
+       |    input in_c : UInt<70>
+       |
+       |    output out_a : UInt<16>
+       |    output out_a_plus_b : UInt<16>
+       |    output out_c : UInt<70>
+       |    output wire_out : UInt<16>
+       |    output reg_out : UInt<16>
+       |
+       |    reg x : UInt<16>, clock with :
+       |      reset => (UInt<1>("h0"), x)
+       |
+       |    x <= in_a
+       |    reg_out <= x
+       |
+       |    out_a <= in_a
+       |    out_a_plus_b <= add(in_a, in_b)
+       |    out_c <= in_c
+       |
+       |    node wire_1 = add(in_b, in_b)
+       |    node wire_2 = add(wire_1, in_a)
+       |
+       |    wire_out <= wire_2
+       |
+       """.stripMargin
+
+  "force value operates on any internal wire" - {
+    "no forces should work as expected" in {
+
+      val manager = new TreadleOptionsManager {
+        treadleOptions = treadleOptions.copy(
+          rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
+      }
+
+      val tester = new TreadleTester(simpleCircuit, manager)
+
+      val bigNum = BigInt("1" * 66, 2)
+
+      tester.poke("in_a", 7)
+      tester.poke("in_b", 77)
+      tester.poke("in_c", bigNum)
+
+      tester.step()
+
+      tester.expect("out_a", 7)
+      tester.expect("wire_out", 161)
+      tester.expect("reg_out", 7)
+      tester.expect("out_a_plus_b", 84)
+      tester.expect("out_c", bigNum)
+    }
+    "force register should work" in {
+
+      val manager = new TreadleOptionsManager {
+        treadleOptions = treadleOptions.copy(
+          rollbackBuffers = 0, showFirrtlAtLoad = true, setVerbose = false, writeVCD = false)
+      }
+
+      val tester = new TreadleTester(simpleCircuit, manager)
+
+      val bigNum = BigInt("1" * 66, 2)
+
+      tester.poke("in_a", 7)
+      tester.poke("in_b", 77)
+      tester.poke("in_c", bigNum)
+
+      tester.forceValue("x", 3)
+
+      tester.step()
+
+      tester.expect("out_a", 7)
+      tester.expect("wire_out", 161)
+      tester.expect("reg_out", 3)
+      tester.expect("out_a_plus_b", 84)
+      tester.expect("out_c", bigNum)
+    }
+    "force wire should work" in {
+
+      val manager = new TreadleOptionsManager {
+        treadleOptions = treadleOptions.copy(
+          rollbackBuffers = 0, showFirrtlAtLoad = true, setVerbose = true, writeVCD = false)
+      }
+
+      val tester = new TreadleTester(simpleCircuit, manager)
+
+      val bigNum = BigInt("1" * 66, 2)
+
+      tester.poke("in_a", 7)
+      tester.poke("in_b", 77)
+      tester.poke("in_c", bigNum)
+
+      tester.step()
+
+      tester.forceValue("wire_1", 10)
+
+      tester.expect("out_a", 7)
+      tester.expect("wire_out", 17)
+      tester.expect("reg_out", 7)
+      tester.expect("out_a_plus_b", 84)
+      tester.expect("out_c", bigNum)
+
+      tester.clearForceValue("wire_1")
+
+      tester.expect("wire_out", 161)
+
+    }
+  }
+}


### PR DESCRIPTION
- Forcing implemented via adding forcedValue option field to symbol.
  - Assignments to wires checks for this value
  - if Some(value) set then sets wire to that instead of ordinary computed value
- Assignment reporting in debug shows forcing information.`
- Added force command
  - force alone shows forced wires
  - force wire value forces wire to value, stays until explicitly cleared
  - force wire clear clears forcing on wire
- TreadleTester API extended
  - forceValue forces wire to value until cleared
  - clearForceValue clears wire
- Added test that shows TreadleTester forcing use
- Cleaned up imports in TreadleRepl