### PR TITLE
Built in async reset support

### DIFF
--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -452,6 +452,7 @@ class ExpressionCompiler(
         case UIntType(IntWidth(n)) => n.toInt
         case SIntType(IntWidth(n)) => n.toInt
         case ClockType             => 1
+        case AsyncResetType        => 1
       }
 
       val sourceWidth = getWidth(expressions.head)
@@ -459,48 +460,51 @@ class ExpressionCompiler(
       arg1 match {
         case e1: IntExpressionResult =>
           op match {
-            case Pad     => e1
-            case AsUInt  => AsUIntInts(e1.apply, width)
-            case AsSInt  => AsSIntInts(e1.apply, width)
-            case AsClock => e1
+            case Pad            => e1
+            case AsUInt         => AsUIntInts(e1.apply, width)
+            case AsSInt         => AsSIntInts(e1.apply, width)
+            case AsClock        => e1
+            case AsAsyncReset   => e1
 
-            case Cvt     => e1
-            case Neg     => NegInts(e1.apply)
-            case Not     => NotInts(e1.apply, width)
+            case Cvt            => e1
+            case Neg            => NegInts(e1.apply)
+            case Not            => NotInts(e1.apply, width)
 
-            case Andr    => AndrInts(e1.apply, sourceWidth)
-            case Orr     => OrrInts(e1.apply,  sourceWidth)
-            case Xorr    => XorrInts(e1.apply, sourceWidth)
+            case Andr           => AndrInts(e1.apply, sourceWidth)
+            case Orr            => OrrInts(e1.apply,  sourceWidth)
+            case Xorr           => XorrInts(e1.apply, sourceWidth)
           }
         case e1: LongExpressionResult =>
           op match {
-            case Pad     => e1
-            case AsUInt  => AsUIntLongs(e1.apply, width)
-            case AsSInt  => AsSIntLongs(e1.apply, width)
-            case AsClock => e1
+            case Pad            => e1
+            case AsUInt         => AsUIntLongs(e1.apply, width)
+            case AsSInt         => AsSIntLongs(e1.apply, width)
+            case AsClock        => e1
+            case AsAsyncReset   => e1
 
-            case Cvt     => e1
-            case Neg     => NegLongs(e1.apply)
-            case Not     => NotLongs(e1.apply, width)
+            case Cvt            => e1
+            case Neg            => NegLongs(e1.apply)
+            case Not            => NotLongs(e1.apply, width)
 
-            case Andr    => AndrLongs(e1.apply, sourceWidth)
-            case Orr     => OrrLongs(e1.apply,  sourceWidth)
-            case Xorr    => XorrLongs(e1.apply, sourceWidth)
+            case Andr           => AndrLongs(e1.apply, sourceWidth)
+            case Orr            => OrrLongs(e1.apply,  sourceWidth)
+            case Xorr           => XorrLongs(e1.apply, sourceWidth)
           }
         case e1: BigExpressionResult =>
           op match {
-            case Pad     => e1
-            case AsUInt  => AsUIntBigs(e1.apply, width)
-            case AsSInt  => AsSIntBigs(e1.apply, width)
-            case AsClock => e1
+            case Pad            => e1
+            case AsUInt         => AsUIntBigs(e1.apply, width)
+            case AsSInt         => AsSIntBigs(e1.apply, width)
+            case AsClock        => e1
+            case AsAsyncReset   => e1
 
-            case Cvt     => e1
-            case Neg     => NegBigs(e1.apply)
-            case Not     => NotBigs(e1.apply, width)
+            case Cvt            => e1
+            case Neg            => NegBigs(e1.apply)
+            case Not            => NotBigs(e1.apply, width)
 
-            case Andr    => AndrBigs(e1.apply, sourceWidth)
-            case Orr     => OrrBigs(e1.apply,  sourceWidth)
-            case Xorr    => XorrBigs(e1.apply, sourceWidth)
+            case Andr           => AndrBigs(e1.apply, sourceWidth)
+            case Orr            => OrrBigs(e1.apply,  sourceWidth)
+            case Xorr           => XorrBigs(e1.apply, sourceWidth)
           }
       }
     }
@@ -603,9 +607,10 @@ class ExpressionCompiler(
 
             case Pad     => unaryOps(op, args, tpe)
 
-            case AsUInt  => unaryOps(op, args, tpe)
-            case AsSInt  => unaryOps(op, args, tpe)
-            case AsClock => unaryOps(op, args, tpe)
+            case AsUInt       => unaryOps(op, args, tpe)
+            case AsSInt       => unaryOps(op, args, tpe)
+            case AsClock      => unaryOps(op, args, tpe)
+            case AsAsyncReset => unaryOps(op, args, tpe)
 
             case Shl => oneArgOneParamOps(op, args, const, tpe)
             case Shr => oneArgOneParamOps(op, args, const, tpe)
@@ -631,6 +636,7 @@ class ExpressionCompiler(
 
             case Head => oneArgOneParamOps(op, args, const, tpe)
             case Tail => oneArgOneParamOps(op, args, const, tpe)
+
             case _ =>
               throw new Exception(s"processExpression:error: unhandled expression $expression")
           }
@@ -760,7 +766,7 @@ class ExpressionCompiler(
       case DefWire(_, name, _) =>
         logger.debug(s"declaration:DefWire:$name")
 
-      case DefRegister(info, name, _, clockExpression, _, _) =>
+      case DefRegister(info, name, tpe, clockExpression, resetExpression, initExpression) =>
 
         logger.debug(s"declaration:DefRegister:$name")
 

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -797,8 +797,12 @@ class ExpressionCompiler(
               makeAssigner(registerOut, asyncResetMux, info = info)
             }
             else {
-              makeAssigner(registerOut, posEdgeMux, info = info)
+              //TODO: (Chick) We could use
+              // makeAssigner(registerOut, posEdgeMux, info = info)
+              // but it causes a slight performance regression
+              val drivingClockOption = getDrivingClock(clockExpression)
 
+              makeAssigner(registerOut, makeGet(registerIn), drivingClockOption, info = info)
             }
           case _ =>
             makeAssigner(registerOut, makeGet(registerIn), info = info)

--- a/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
+++ b/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
@@ -151,6 +151,7 @@ class ExpressionViewBuilder(
               case AsUInt  => unaryOps(op, args, tpe)
               case AsSInt  => unaryOps(op, args, tpe)
               case AsClock => unaryOps(op, args, tpe)
+              case AsAsyncReset => unaryOps(op, args, tpe)
 
               case Shl => oneArgOneParamOps(op, args, const, tpe)
               case Shr => oneArgOneParamOps(op, args, const, tpe)

--- a/src/main/scala/treadle/executable/Symbol.scala
+++ b/src/main/scala/treadle/executable/Symbol.scala
@@ -125,6 +125,7 @@ object DataSize {
       case firrtl.ir.SIntType(IntWidth(bitWidth)) => bitWidth.toInt
       case firrtl.ir.UIntType(IntWidth(bitWidth)) => bitWidth.toInt
       case firrtl.ir.ClockType                    => 1
+      case firrtl.ir.AsyncResetType               => 1
       case _ =>
         throw TreadleException(s"Error:DataSize doesn't know size of $firrtlType")
     }
@@ -163,9 +164,10 @@ object DataType {
 
   def apply(tpe: firrtl.ir.Type): DataType = {
     tpe match {
-      case _: firrtl.ir.SIntType => SignedInt
-      case _: firrtl.ir.UIntType => UnsignedInt
-      case firrtl.ir.ClockType   => UnsignedInt
+      case _: firrtl.ir.SIntType    => SignedInt
+      case _: firrtl.ir.UIntType    => UnsignedInt
+      case firrtl.ir.ClockType      => UnsignedInt
+      case firrtl.ir.AsyncResetType => UnsignedInt
       case t =>
         throw TreadleException(s"DataType does not know firrtl type $t")
     }

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -362,6 +362,9 @@ object SymbolTable extends LazyLogging {
 
           addDependency(registerOut, expressionToReferences(clockExpression))
           addDependency(registerIn, expressionToReferences(resetExpression))
+          if(resetExpression.tpe == AsyncResetType) {
+            addDependency(registerOut, expressionToReferences(resetExpression))
+          }
           addDependency(registerIn, Set(registerOut))
 
           registerToClock(registerOut) = expressionToReferences(clockExpression).head

--- a/src/test/scala/treadle/NativeAsyncResetSpec.scala
+++ b/src/test/scala/treadle/NativeAsyncResetSpec.scala
@@ -32,7 +32,7 @@ class NativeAsyncResetSpec extends FreeSpec with Matchers {
 
     val manager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
-        rollbackBuffers = 0, showFirrtlAtLoad = true, setVerbose = true, writeVCD = false)
+        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
     }
     val tester = TreadleTester(firrtlSource, manager)
 

--- a/src/test/scala/treadle/NativeAsyncResetSpec.scala
+++ b/src/test/scala/treadle/NativeAsyncResetSpec.scala
@@ -69,4 +69,69 @@ class NativeAsyncResetSpec extends FreeSpec with Matchers {
     tester.report()
     tester.finish
   }
+  "async reset should work when declared as IO" in {
+    val firrtlSource =
+      """
+        |circuit SimpleCircuit :
+        |  module SimpleCircuit :
+        |    input clock : Clock
+        |
+        |    input a_reset : AsyncReset
+        |    input reset : UInt<1>
+        |
+        |    input in : UInt<8>
+        |    output out_reg : UInt<8>
+        |    output out_async_reg : UInt<8>
+        |
+        |    reg reg      : UInt<8>, clock with : (reset => (reset, UInt(17)))
+        |    reg asyncReg : UInt<8>, clock with : (reset => (a_reset, UInt(17)))
+        |
+        |    reg <= in
+        |    asyncReg <= in
+        |    out_reg <= reg
+        |    out_async_reg <= asyncReg
+        |
+      """.stripMargin
+
+    val manager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
+    }
+    val tester = TreadleTester(firrtlSource, manager)
+
+    tester.poke("in", 7)
+    tester.expect("out_reg", 0)
+    tester.expect("out_async_reg", 0)
+
+    tester.step()
+
+    tester.expect("out_reg", 7)
+    tester.expect("out_async_reg", 7)
+
+    tester.poke("in", 23)
+    tester.poke("reset", 1)
+    tester.poke("a_reset", 1)
+
+    tester.expect("reg", 7)
+    tester.expect("out_async_reg", 17)
+
+    tester.step()
+
+    tester.expect("reg", 17)
+    tester.expect("out_async_reg", 17)
+
+    tester.poke("reset", 0)
+    tester.poke("a_reset", 0)
+
+    tester.expect("out_reg", 17)
+    tester.expect("out_async_reg", 17)
+
+    tester.step()
+
+    tester.expect("out_reg", 23)
+    tester.expect("out_async_reg", 23)
+
+    tester.report()
+    tester.finish
+  }
 }

--- a/src/test/scala/treadle/NativeAsyncResetSpec.scala
+++ b/src/test/scala/treadle/NativeAsyncResetSpec.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package treadle
+
+import org.scalatest.{FreeSpec, Matchers}
+
+class NativeAsyncResetSpec extends FreeSpec with Matchers {
+  "native firrtl async reset should work" in {
+    val firrtlSource =
+      """
+        |circuit SimpleCircuit :
+        |  module SimpleCircuit :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    input in : UInt<8>
+        |    output out : UInt<8>
+        |    wire areset : AsyncReset
+        |    reg r : UInt<8>, clock with : (reset => (areset, UInt(0)))
+        |    areset <= asAsyncReset(reset)
+        |    r <= in
+        |    out <= r
+        |
+      """.stripMargin
+
+    val manager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        rollbackBuffers = 0, showFirrtlAtLoad = true, setVerbose = true, writeVCD = false)
+    }
+    val tester = TreadleTester(firrtlSource, manager)
+
+    tester.poke("in", 7)
+    tester.expect("out", 0)
+
+    tester.step()
+
+    tester.poke("in", 23)
+    tester.poke("reset", 1)
+    tester.expect("out", 23)
+
+    tester.report()
+    tester.finish
+  }
+}


### PR DESCRIPTION
- Add proper references to handle AsyncReset stuff appearing in AST
- Added test that will be used for testing built-in support
- Modify assigners constructed during DefRegister handler
  - now muxes register out assignment using treadle operators
  - with regular reset, muxes register out depending on clock transition
  - with async muxes above with init value depending on reset value
- Expanded NativeAsyncResetSpec
  - compares behavior to regular register
- Fix up ExpressionView rendering to match new register assignment methodology
- remove debug from test