### PR TITLE
Quick fix (hack) for Stage/Phase CircuitForm issues.

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -5,7 +5,7 @@ package treadle
 import java.io.PrintWriter
 import java.util.Calendar
 
-import firrtl.AnnotationSeq
+import firrtl.{AnnotationSeq, ChirrtlForm, CircuitForm}
 import firrtl.options.StageOptions
 import firrtl.options.Viewer.view
 import firrtl.stage.{FirrtlSourceAnnotation, OutputFileAnnotation}
@@ -31,8 +31,8 @@ import treadle.stage.{TreadleCompatibilityPhase, TreadleTesterPhase}
 //class TreadleTester(input: String, optionsManager: HasTreadleSuite = TreadleTester.getDefaultManager) {
 class TreadleTester(annotationSeq: AnnotationSeq) {
 
-  def this(input: String, optionsManager: HasTreadleSuite) = {
-    this(TreadleCompatibilityPhase.transform(optionsManager.toAnnotationSeq :+ FirrtlSourceAnnotation(input)))
+  def this(input: String, optionsManager: HasTreadleSuite, circuitForm: CircuitForm = ChirrtlForm) = {
+    this(TreadleCompatibilityPhase.checkFormTransform(circuitForm, optionsManager.toAnnotationSeq :+ FirrtlSourceAnnotation(input)))
   }
 
   var expectationsMet = 0

--- a/src/main/scala/treadle/stage/TreadleStage.scala
+++ b/src/main/scala/treadle/stage/TreadleStage.scala
@@ -2,19 +2,35 @@
 
 package treadle.stage
 
-import firrtl.AnnotationSeq
+import firrtl.{AnnotationSeq, ChirrtlForm, CircuitForm, LowForm}
 import firrtl.options.{Phase, Shell, Stage}
 import firrtl.stage.FirrtlCli
-import treadle.stage.phases.{CreateTester, GetFirrtlAst, PrepareAst, SetImplicitOutputInfo}
+import treadle.stage.phases.{CreateTester, GetFirrtlAst, PrepareAst, PrepareAstFromLowFIRRTL, SetImplicitOutputInfo}
 
 object TreadleCompatibilityPhase extends Phase {
-  private val phases: Seq[Phase] = Seq(
+  private val chirrtlPhases: Seq[Phase] = Seq(
     GetFirrtlAst,
     SetImplicitOutputInfo,
     PrepareAst
   )
+  private val lowFIRRTLPhases: Seq[Phase] = Seq(
+    GetFirrtlAst,
+    SetImplicitOutputInfo,
+    PrepareAstFromLowFIRRTL
+  )
 
   override def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    chirrtlPhases.foldLeft(annotations)( (a, f) => f.transform(a) )
+  }
+
+  /** Here to determine which phases to run based on the circuit form.
+    *
+    */
+  def checkFormTransform(circuitForm: CircuitForm, annotations: AnnotationSeq): AnnotationSeq = {
+    val phases = circuitForm match {
+      case ChirrtlForm => chirrtlPhases
+      case LowForm => lowFIRRTLPhases
+    }
     phases.foldLeft(annotations)( (a, f) => f.transform(a) )
   }
 }

--- a/src/main/scala/treadle/stage/phases/PrepareAst.scala
+++ b/src/main/scala/treadle/stage/phases/PrepareAst.scala
@@ -10,12 +10,8 @@ import firrtl.{AnnotationSeq, ChirrtlForm, CircuitState, HighForm, LowFirrtlOpti
 import treadle.TreadleCircuitStateAnnotation
 import treadle.utils.{AugmentPrintf, FixupOps}
 
-/**
-  * Call a bunch of transforms so TreadleTester can operate
-  */
-object PrepareAst extends Phase {
-  val transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, LowForm) ++
-          Seq(new LowFirrtlOptimization, new BlackBoxSourceHelper, new FixupOps, AugmentPrintf)
+trait TreadlePhase extends Phase {
+  val transforms: Seq[Transform]
 
   override def transform(annotationSeq: AnnotationSeq): AnnotationSeq = {
     annotationSeq.flatMap {
@@ -27,4 +23,18 @@ object PrepareAst extends Phase {
         Some(other)
     }
   }
+}
+
+/** Prepare the AST from low FIRRTL.
+  *
+  */
+object PrepareAstFromLowFIRRTL extends TreadlePhase {
+  val transforms: Seq[Transform] = Seq(new FixupOps, AugmentPrintf)
+}
+/**
+  * Call a bunch of transforms so TreadleTester can operate
+  */
+object PrepareAst extends TreadlePhase {
+  val transforms: Seq[Transform] = getLoweringTransforms(ChirrtlForm, LowForm) ++
+    Seq(new LowFirrtlOptimization, new BlackBoxSourceHelper, new FixupOps, AugmentPrintf)
 }


### PR DESCRIPTION
Provide an argument to TreadleTester to specify what form the circuit is in,
Define PrepareAstFromLowFIRRTL object which avoids the "normal" FIRRTL transforms if we're already in LowForm. **NOTE** - trying to refactor this so the two sets of transforms (FIRRTL and Treadle) are composable doesn't appear to work.
Define checkFormTransform method in TreadleCompatibilityPhase which determines which phases are to be run based on the circuit form.

This requires some discussion. Notably, why isn't the CircuitForm a property of the Circuit itself?
