### PR TITLE
Abstract rollback buffers

### DIFF
--- a/src/main/scala/treadle/ScalaBlackBox.scala
+++ b/src/main/scala/treadle/ScalaBlackBox.scala
@@ -3,7 +3,7 @@
 package treadle
 
 import firrtl.ir.{Param, Type}
-import treadle.executable.{DataStore, Symbol, Transition}
+import treadle.executable.Transition
 
 import scala.collection._
 

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -448,7 +448,7 @@ object TreadleTester {
     * @param optionsManager  options manager
     * @return
     */
-  @deprecated("Use TreadleTester(annotationSeq) instead")
+  @deprecated("Use TreadleTester(annotationSeq) instead", "since ")
   def apply(input : String, optionsManager: HasTreadleSuite = getDefaultManager): TreadleTester = {
     val sourceAnnotation = FirrtlSourceAnnotation(input)
     TreadleTester(sourceAnnotation +: optionsManager.toAnnotationSeq)

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -90,7 +90,6 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
 
       SimpleSingleClockStepper(
         engine,
-        engine.dataStore,
         engine.symbolTable(clockInfo.name),
         engine.symbolTable.get(resetName),
         clockInfo.period,

--- a/src/main/scala/treadle/executable/BlackBoxCycler.scala
+++ b/src/main/scala/treadle/executable/BlackBoxCycler.scala
@@ -18,7 +18,7 @@ case class BlackBoxCycler(
   symbol:                Symbol,
   blackBox:              ScalaBlackBox,
   clockSymbol:           Symbol,
-  clockTransitionGetter: ClockTransitionGetter,
+  clockTransitionGetter: AbstractClockTransitionGetter,
   info:                  Info
 )
 extends Assigner {

--- a/src/main/scala/treadle/executable/ClockStepper.scala
+++ b/src/main/scala/treadle/executable/ClockStepper.scala
@@ -31,7 +31,6 @@ case class ClockAssigners(upAssigner: Assigner, downAssigner: Assigner)
 
 case class SimpleSingleClockStepper(
   engine: ExecutionEngine,
-  dataStore: DataStore,
   clockSymbol: Symbol,
   resetSymbolOpt: Option[Symbol],
   clockPeriod: Long,
@@ -177,7 +176,6 @@ case class SimpleSingleClockStepper(
   * @param wallTime       handle to top level wall time
   */
 class MultiClockStepper(engine: ExecutionEngine, clockInfoList: Seq[ClockInfo], wallTime: UTC) extends ClockStepper {
-  val dataStore: DataStore = engine.dataStore
   val scheduler: Scheduler = engine.scheduler
   val hasRollBack: Boolean = engine.dataStore.numberOfBuffers > 0
 

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -605,7 +605,12 @@ object DataStore {
   }
 }
 
-trait HasDataArrays {
+trait DataReader {
+  def apply(symbol: Symbol): Big
+  def apply(symbol: Symbol, offset: Int): Big
+}
+
+trait HasDataArrays extends DataReader {
   def intData  : Array[Int]
   def longData : Array[Long]
   def bigData  : Array[Big]

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -118,7 +118,7 @@ extends HasDataArrays {
     }
   }
 
-  @deprecated("Use saveData(time: Long), clock based rollback buffers are no longer supported")
+  @deprecated("Use saveData(time: Long), clock based rollback buffers are no longer supported", "since 1.0")
   def saveData(clockName: String, time: Long): Unit = {
     if(numberOfBuffers > 0) {
       rollBackBufferManager.saveData(time)
@@ -173,9 +173,9 @@ extends HasDataArrays {
     }
 
     override def setLeanMode(isLean: Boolean): Unit = {
-      run = if(isLean) runLean else runFull
+      run = if(isLean) runLean _ else runFull _
     }
-    var run: FuncUnit = runLean
+    var run: FuncUnit = runLean _
   }
 
   case class ExternalModuleInputAssigner(
@@ -214,12 +214,12 @@ extends HasDataArrays {
 
     override def setLeanMode(isLean: Boolean): Unit = {
       run = if(isLean) {
-        runLean
+        runLean _
       } else {
-        runFull
+        runFull _
       }
     }
-    var run: FuncUnit = runLean
+    var run: FuncUnit = runLean _
   }
 
   case class GetBig(index: Int) extends BigExpressionResult {
@@ -240,9 +240,9 @@ extends HasDataArrays {
     }
 
     override def setLeanMode(isLean: Boolean): Unit = {
-      run = if(isLean) runLean else runFull
+      run = if(isLean) runLean _ else runFull _
     }
-    var run: FuncUnit = runLean
+    var run: FuncUnit = runLean _
   }
 
   /** for memory implementations */
@@ -306,9 +306,9 @@ extends HasDataArrays {
     }
 
     override def setLeanMode(isLean: Boolean): Unit = {
-      run = if(isLean) runLean else runFull
+      run = if(isLean) runLean _  else runFull _
     }
-    var run: FuncUnit = runLean
+    var run: FuncUnit = runLean _
   }
 
   case class AssignLongIndirect(
@@ -338,9 +338,9 @@ extends HasDataArrays {
     }
 
     override def setLeanMode(isLean: Boolean): Unit = {
-      run = if(isLean) runLean else runFull
+      run = if(isLean) runLean _ else runFull _
     }
-    var run: FuncUnit = runLean
+    var run: FuncUnit = runLean _
   }
 
   case class AssignBigIndirect(
@@ -370,9 +370,9 @@ extends HasDataArrays {
     }
 
     override def setLeanMode(isLean: Boolean): Unit = {
-      run = if(isLean) runLean else runFull
+      run = if(isLean) runLean _ else runFull _
     }
-    var run: FuncUnit = runLean
+    var run: FuncUnit = runLean _
   }
 
   case class BlackBoxShim(

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -392,22 +392,6 @@ extends HasDataArrays {
     }
   }
 
-  def apply(symbol: Symbol): Big = {
-    symbol.dataSize match {
-      case IntSize  => intData(symbol.index)
-      case LongSize => longData(symbol.index)
-      case BigSize  => bigData(symbol.index)
-    }
-  }
-
-  def apply(symbol: Symbol, offset: Int): Big = {
-    symbol.dataSize match {
-      case IntSize  => intData(symbol.index + offset)
-      case LongSize => longData(symbol.index + offset)
-      case BigSize  => bigData(symbol.index + offset)
-    }
-  }
-
   def getWaveformValues(symbols: Array[Symbol], startCycle: Int = 0, endCycle: Int = -1): WaveformValues = {
     var buffers: Seq[RollBackBuffer] = rollBackBufferManager.newestToOldestBuffers.reverse
 
@@ -625,20 +609,20 @@ trait HasDataArrays {
   def intData  : Array[Int]
   def longData : Array[Long]
   def bigData  : Array[Big]
-
-  def setValueAtIndex(dataSize: DataSize, index: Int, value: Big): Unit = {
-    dataSize match {
-      case IntSize  => intData(index)  = value.toInt
-      case LongSize => longData(index) = value.toLong
-      case BigSize  => bigData(index)  = value
+  
+  def apply(symbol: Symbol): Big = {
+    symbol.dataSize match {
+      case IntSize  => intData(symbol.index)
+      case LongSize => longData(symbol.index)
+      case BigSize  => bigData(symbol.index)
     }
   }
 
-  def getValueAtIndex(dataSize: DataSize, index: Int): BigInt = {
-    dataSize match {
-      case IntSize  => intData(index)
-      case LongSize => longData(index)
-      case BigSize  => bigData(index)
+  def apply(symbol: Symbol, offset: Int): Big = {
+    symbol.dataSize match {
+      case IntSize  => intData(symbol.index + offset)
+      case LongSize => longData(symbol.index + offset)
+      case BigSize  => bigData(symbol.index + offset)
     }
   }
 }

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -110,10 +110,10 @@ extends HasDataArrays with AbstractDataStore {
   val longData:  Array[Long] = Array.fill(numberOfLongs)(0L)
   val bigData:   Array[Big]  = Array.fill(numberOfBigs)(Big(0))
 
-  val rollBackBufferManager = new RollBackBufferManager(this)
+  val rollBackBufferManager = new RollBackBufferManager(numberOfBuffers, new RollBackBuffer(this))
 
-  def findBufferBeforeClockTransition(time: Long, clockIndex: Int, prevClockIndex: Int): Option[RollBackBuffer] =
-    rollBackBufferManager.findBufferBeforeClockTransition(time, clockIndex, prevClockIndex)
+  def findBufferBeforeClockTransition(time: Long, clock: Symbol, prevClock: Symbol): Option[DataBuffer] =
+    rollBackBufferManager.findBufferBeforeClockTransition(time, clock, prevClock)
 
   def saveData(time: Long): Unit = {
     if(numberOfBuffers > 0) {
@@ -640,8 +640,10 @@ trait DataPluginHost {
 
 }
 
+/** A DataBuffer is the a snapshot of a [[AbstractDataStore]] at a particular time. */
 trait DataBuffer extends DataReader {
   def getTime: Long
+  def dump(dumpTime: Long): Unit
 }
 
 trait AbstractDataStore extends DataReader with DataWriter with DataSerializer with DataPluginHost {
@@ -649,7 +651,7 @@ trait AbstractDataStore extends DataReader with DataWriter with DataSerializer w
   val numberOfBuffers: Int
   def setExecutionEngine(executionEngine: ExecutionEngine): Unit
   def saveData(time: Long): Unit
-  def findBufferBeforeClockTransition(time: Long, clockIndex: Int, prevClockIndex: Int): Option[DataBuffer]
+  def findBufferBeforeClockTransition(time: Long, clock: Symbol, prevClock: Symbol): Option[DataBuffer]
   def makeConstantAssigner(symbol: Symbol, value: Big, info: Info) : Assigner
   def getWaveformValues(symbols: Array[Symbol], startCycle: Int = 0, endCycle: Int = -1): WaveformValues
 }

--- a/src/main/scala/treadle/executable/DataStorePlugIn.scala
+++ b/src/main/scala/treadle/executable/DataStorePlugIn.scala
@@ -6,7 +6,7 @@ import treadle.vcd.VCD
 
 abstract class DataStorePlugin {
   def executionEngine: ExecutionEngine
-  def dataStore: DataStore
+  def dataStore: AbstractDataStore
   var isEnabled: Boolean = false
 
   def setEnabled(enabled: Boolean): Unit = {
@@ -33,7 +33,7 @@ abstract class DataStorePlugin {
 }
 
 class ReportAssignments(val executionEngine: ExecutionEngine) extends DataStorePlugin {
-  val dataStore: DataStore = executionEngine.dataStore
+  val dataStore: AbstractDataStore = executionEngine.dataStore
 
   def run(symbol: Symbol, offset: Int = -1): Unit = {
     if(offset == -1) {
@@ -64,7 +64,7 @@ class RenderComputations(
   symbolNamesToWatch: Seq[String]
 ) extends DataStorePlugin {
 
-  val dataStore: DataStore = executionEngine.dataStore
+  val dataStore: AbstractDataStore = executionEngine.dataStore
   val symbolsToWatch: Set[Symbol] = symbolNamesToWatch.flatMap { name =>
     executionEngine.symbolTable.get(name)
   }.toSet
@@ -80,7 +80,7 @@ class RenderComputations(
 }
 
 class VcdHook(val executionEngine: ExecutionEngine, val vcd: VCD) extends DataStorePlugin {
-  val dataStore: DataStore = executionEngine.dataStore
+  val dataStore: AbstractDataStore = executionEngine.dataStore
 
   override def run(symbol: Symbol, offset: Int = -1): Unit = {
     if(offset == -1) {

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -187,7 +187,7 @@ class ExecutionEngine(
       if(offset - 1 > symbol.slots) {
         throw TreadleException(s"get value from ${symbol.name} offset $offset > than size ${symbol.slots}")
       }
-      symbol.normalize(dataStore.getValueAtIndex(symbol.dataSize, index = symbol.index + offset))
+      symbol.normalize(dataStore(symbol, offset))
     }
   }
 
@@ -257,7 +257,7 @@ class ExecutionEngine(
 
         println(s"${symbol.name}($offset) <= $value from tester")
       }
-      dataStore.setValueAtIndex(symbol.dataSize, symbol.index + offset, value)
+      dataStore.update(symbol, offset, value)
     }
 
     value

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -472,7 +472,7 @@ object ExecutionEngine {
 
     val dataStoreAllocator = new DataStoreAllocator
 
-    symbolTable.allocateData(dataStoreAllocator)
+    symbolTable.allocateData(sym => dataStoreAllocator.getIndex(sym.dataSize, sym.slots))
 
     val dataStore = DataStore(rollbackBuffers, dataStoreAllocator)
 
@@ -489,7 +489,7 @@ object ExecutionEngine {
     }
 
     val expressionViews: Map[Symbol, ExpressionView] = ExpressionViewBuilder.getExpressionViews(
-      symbolTable, dataStore, scheduler,
+      symbolTable, scheduler,
       validIfIsRandom,
       circuit, blackBoxFactories)
 

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -424,7 +424,7 @@ class ExecutionEngine(
   class NullToggler extends ClockToggle
 
   def makeUpToggler(symbol: Symbol): Assigner = {
-    val assigner = dataStore.AssignInt(symbol, GetIntConstant(1).apply, NoInfo)
+    val assigner = dataStore.AssignInt(symbol, GetIntConstant(1).apply _, NoInfo)
 
     if(vcdOption.isDefined) assigner.setLeanMode(false)
     assigner.setVerbose(verbose)
@@ -432,7 +432,7 @@ class ExecutionEngine(
   }
 
   def makeDownToggler(symbol: Symbol): Assigner = {
-    val assigner = dataStore.AssignInt(symbol, GetIntConstant(0).apply, NoInfo)
+    val assigner = dataStore.AssignInt(symbol, GetIntConstant(0).apply _, NoInfo)
 
     if(vcdOption.isDefined) assigner.setLeanMode(false)
     assigner.setVerbose(verbose)

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -16,7 +16,7 @@ class ExecutionEngine(
     val ast             : Circuit,
     val annotationSeq   : AnnotationSeq,
     val symbolTable     : SymbolTable,
-    val dataStore       : DataStore,
+    val dataStore       : AbstractDataStore,
     val scheduler       : Scheduler,
     val expressionViews : Map[Symbol, ExpressionView],
     val wallTime        : UTC
@@ -295,7 +295,7 @@ class ExecutionEngine(
       }
       println(s"${symbol.name} <= $value")
     }
-    dataStore.intData(symbol.index) = value
+    dataStore.update(symbol, value)
     vcdOption.foreach { vcd =>
       vcd.wireChanged(symbol.name, adjustedValue, symbol.bitWidth)
     }
@@ -424,7 +424,7 @@ class ExecutionEngine(
   class NullToggler extends ClockToggle
 
   def makeUpToggler(symbol: Symbol): Assigner = {
-    val assigner = dataStore.AssignInt(symbol, GetIntConstant(1).apply _, NoInfo)
+    val assigner = dataStore.makeConstantAssigner(symbol, 1, NoInfo)
 
     if(vcdOption.isDefined) assigner.setLeanMode(false)
     assigner.setVerbose(verbose)
@@ -432,7 +432,7 @@ class ExecutionEngine(
   }
 
   def makeDownToggler(symbol: Symbol): Assigner = {
-    val assigner = dataStore.AssignInt(symbol, GetIntConstant(0).apply _, NoInfo)
+    val assigner = dataStore.makeConstantAssigner(symbol, 0, NoInfo)
 
     if(vcdOption.isDefined) assigner.setLeanMode(false)
     assigner.setVerbose(verbose)

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -17,7 +17,7 @@ class ExpressionCompiler(
     validIfIsRandom  : Boolean,
     blackBoxFactories: Seq[ScalaBlackBoxFactory]
 )
-  extends logger.LazyLogging {
+  extends logger.LazyLogging with AbstractExpressionCompiler {
 
   case class ExternalInputParams(instance: ScalaBlackBox, portName: String)
 
@@ -140,16 +140,16 @@ class ExpressionCompiler(
   def makeIndirectAssigner(
     portSymbol       : Symbol,
     memorySymbol     : Symbol,
-    memoryIndex      : Int,
-    enableIndex      : Int,
+    addr             : Symbol,
+    enable           : Symbol,
     expressionResult : ExpressionResult,
     clock            : Symbol,
     info             : Info
   ): Unit = {
 
-    def getIndex = dataStore.GetInt(memoryIndex).apply _
+    def getIndex = dataStore.GetInt(addr.index).apply _
     def getEnable = {
-      dataStore.GetInt(enableIndex).apply _
+      dataStore.GetInt(enable.index).apply _
     }
 
     val assigner = (memorySymbol.dataSize, expressionResult) match {
@@ -941,4 +941,15 @@ class ExpressionCompiler(
 
     processModule("", module, circuit)
   }
+}
+
+trait AbstractExpressionCompiler {
+  def compile(circuit: Circuit, blackBoxFactories: Seq[ScalaBlackBoxFactory]): Unit
+  def makeGet(source: Symbol): ExpressionResult
+  def makeGetIndirect(memory: Symbol, data: Symbol, enable: Symbol, addr: Symbol): ExpressionResult
+  def makeAssigner(symbol: Symbol, expressionResult: ExpressionResult, conditionalClockSymbol: Option[Symbol] = None,
+                   info: Info)
+  def makeIndirectAssigner(portSymbol: Symbol, memorySymbol: Symbol, addr: Symbol, enable: Symbol,
+                           expressionResult: ExpressionResult, clock: Symbol, info: Info)
+  def makeAnd(e1: ExpressionResult, e2: ExpressionResult, resultWidth: Int): ExpressionResult
 }

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
 
 class ExpressionCompiler(
     val symbolTable  : SymbolTable,
-    val dataStore    : DataStore,
+    private val dataStore : DataStore,
     scheduler        : Scheduler,
     validIfIsRandom  : Boolean,
     blackBoxFactories: Seq[ScalaBlackBoxFactory]
@@ -176,6 +176,14 @@ class ExpressionCompiler(
           s"Error:assignment size mismatch ($size)${memorySymbol.name} <= ($expressionSize)$expressionResult")
     }
     addAssigner(assigner)
+  }
+
+  // this function is used by the memory compiler to combine some boolean signals
+  def makeAnd(e1: ExpressionResult, e2: ExpressionResult, resultWidth: Int): ExpressionResult = (e1, e2) match {
+    case (a: IntExpressionResult, b: IntExpressionResult) => {
+      AndInts(a.apply _, b.apply _, resultWidth)
+    }
+    case _=> throw new RuntimeException("makeAnd only implemented for Int & Int!")
   }
 
   //scalastyle:off method.length

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -69,15 +69,15 @@ class ExpressionCompiler(
     data.dataSize match {
       case IntSize =>
         dataStore.GetIntIndirect(
-          memory, dataStore.GetInt(addr.index).apply, dataStore.GetInt(enable.index).apply
+          memory, dataStore.GetInt(addr.index).apply _, dataStore.GetInt(enable.index).apply _
         )
       case LongSize =>
         dataStore.GetLongIndirect(
-          memory, dataStore.GetInt(addr.index).apply, dataStore.GetInt(enable.index).apply
+          memory, dataStore.GetInt(addr.index).apply _, dataStore.GetInt(enable.index).apply _
         )
       case BigSize =>
         dataStore.GetBigIndirect(
-          memory, dataStore.GetInt(addr.index).apply, dataStore.GetInt(enable.index).apply
+          memory, dataStore.GetInt(addr.index).apply _, dataStore.GetInt(enable.index).apply _
         )
     }
   }
@@ -91,20 +91,20 @@ class ExpressionCompiler(
   ): Unit = {
     val assigner = (symbol.dataSize, expressionResult) match {
       case (IntSize,  result: IntExpressionResult)  =>
-        dataStore.AssignInt(symbol, result.apply, info)
+        dataStore.AssignInt(symbol, result.apply _, info)
 
       case (IntSize,  result: LongExpressionResult) =>
-          dataStore.AssignInt(symbol,  ToInt(result.apply).apply, info)
+          dataStore.AssignInt(symbol,  ToInt(result.apply _).apply _, info)
 
       case (IntSize,  result: BigExpressionResult)  =>
-          dataStore.AssignInt(symbol,  ToInt(result.apply).apply, info)
+          dataStore.AssignInt(symbol,  ToInt(result.apply _).apply _, info)
 
-      case (LongSize, result: IntExpressionResult)  => dataStore.AssignLong(symbol, ToLong(result.apply).apply, info)
-      case (LongSize, result: LongExpressionResult) => dataStore.AssignLong(symbol, result.apply, info)
-      case (LongSize, result: BigExpressionResult)  => dataStore.AssignLong(symbol, BigToLong(result.apply).apply, info)
-      case (BigSize,  result: IntExpressionResult)  => dataStore.AssignBig(symbol,  ToBig(result.apply).apply, info)
-      case (BigSize,  result: LongExpressionResult) => dataStore.AssignBig(symbol,  LongToBig(result.apply).apply, info)
-      case (BigSize,  result: BigExpressionResult)  => dataStore.AssignBig(symbol,  result.apply, info)
+      case (LongSize, result: IntExpressionResult)  => dataStore.AssignLong(symbol, ToLong(result.apply _).apply _, info)
+      case (LongSize, result: LongExpressionResult) => dataStore.AssignLong(symbol, result.apply _, info)
+      case (LongSize, result: BigExpressionResult)  => dataStore.AssignLong(symbol, BigToLong(result.apply _).apply _, info)
+      case (BigSize,  result: IntExpressionResult)  => dataStore.AssignBig(symbol,  ToBig(result.apply _).apply _, info)
+      case (BigSize,  result: LongExpressionResult) => dataStore.AssignBig(symbol,  LongToBig(result.apply _).apply _, info)
+      case (BigSize,  result: BigExpressionResult)  => dataStore.AssignBig(symbol,  result.apply _, info)
       case (size, result) =>
         val expressionSize = result match {
           case _: IntExpressionResult => "Int"
@@ -154,17 +154,17 @@ class ExpressionCompiler(
 
     val assigner = (memorySymbol.dataSize, expressionResult) match {
       case (IntSize, result: IntExpressionResult) =>
-        dataStore.AssignIntIndirect(portSymbol, memorySymbol, getIndex, getEnable, result.apply, info)
+        dataStore.AssignIntIndirect(portSymbol, memorySymbol, getIndex, getEnable, result.apply _, info)
       case (LongSize, result: IntExpressionResult) =>
-        dataStore.AssignLongIndirect(portSymbol, memorySymbol, getIndex, getEnable, ToLong(result.apply).apply, info)
+        dataStore.AssignLongIndirect(portSymbol, memorySymbol, getIndex, getEnable, ToLong(result.apply _).apply _, info)
       case (LongSize, result: LongExpressionResult) =>
-        dataStore.AssignLongIndirect(portSymbol, memorySymbol, getIndex, getEnable, result.apply, info)
+        dataStore.AssignLongIndirect(portSymbol, memorySymbol, getIndex, getEnable, result.apply _, info)
       case (BigSize, result: IntExpressionResult) =>
-        dataStore.AssignBigIndirect(portSymbol, memorySymbol, getIndex, getEnable, ToBig(result.apply).apply, info)
+        dataStore.AssignBigIndirect(portSymbol, memorySymbol, getIndex, getEnable, ToBig(result.apply _).apply _, info)
       case (BigSize, result: LongExpressionResult) =>
-        dataStore.AssignBigIndirect(portSymbol, memorySymbol, getIndex, getEnable, LongToBig(result.apply).apply, info)
+        dataStore.AssignBigIndirect(portSymbol, memorySymbol, getIndex, getEnable, LongToBig(result.apply _).apply _, info)
       case (BigSize, result: BigExpressionResult) =>
-        dataStore.AssignBigIndirect(portSymbol, memorySymbol, getIndex, getEnable, result.apply, info)
+        dataStore.AssignBigIndirect(portSymbol, memorySymbol, getIndex, getEnable, result.apply _, info)
       case (size, result) =>
         val expressionSize = result match {
           case _: IntExpressionResult => "Int"
@@ -206,28 +206,28 @@ class ExpressionCompiler(
 
       def handleIntResult(e1: IntExpressionResult, e2: IntExpressionResult): ExpressionResult = {
         opCode match {
-          case Add => AddInts(e1.apply, e2.apply)
-          case Sub => SubInts(e1.apply, e2.apply)
-          case Mul => MulInts(e1.apply, e2.apply)
-          case Div => DivInts(e1.apply, e2.apply)
-          case Rem => RemInts(e1.apply, e2.apply)
+          case Add => AddInts(e1.apply _, e2.apply _)
+          case Sub => SubInts(e1.apply _, e2.apply _)
+          case Mul => MulInts(e1.apply _, e2.apply _)
+          case Div => DivInts(e1.apply _, e2.apply _)
+          case Rem => RemInts(e1.apply _, e2.apply _)
 
-          case Eq  => EqInts(e1.apply,  e2.apply)
-          case Neq => NeqInts(e1.apply, e2.apply)
-          case Lt  => LtInts(e1.apply,  e2.apply)
-          case Leq => LeqInts(e1.apply, e2.apply)
-          case Gt  => GtInts(e1.apply,  e2.apply)
-          case Geq => GeqInts(e1.apply, e2.apply)
+          case Eq  => EqInts(e1.apply _,  e2.apply _)
+          case Neq => NeqInts(e1.apply _, e2.apply _)
+          case Lt  => LtInts(e1.apply _,  e2.apply _)
+          case Leq => LeqInts(e1.apply _, e2.apply _)
+          case Gt  => GtInts(e1.apply _,  e2.apply _)
+          case Geq => GeqInts(e1.apply _, e2.apply _)
 
-          case Dshl => DshlInts(e1.apply, e2.apply)
-          case Dshr => DshrInts(e1.apply, e2.apply)
+          case Dshl => DshlInts(e1.apply _, e2.apply _)
+          case Dshr => DshrInts(e1.apply _, e2.apply _)
 
-          case And => AndInts(e1.apply, e2.apply, arg1Width.max(arg2Width))
-          case Or  => OrInts(e1.apply,  e2.apply, arg1Width.max(arg2Width))
-          case Xor => XorInts(e1.apply, e2.apply, arg1Width.max(arg2Width))
+          case And => AndInts(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
+          case Or  => OrInts(e1.apply _,  e2.apply _, arg1Width.max(arg2Width))
+          case Xor => XorInts(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
 
           case Cat =>
-            CatInts(e1.apply, arg1Width, e2.apply, arg2Width)
+            CatInts(e1.apply _, arg1Width, e2.apply _, arg2Width)
 
           case _ =>
             throw TreadleException(s"Error:BinaryOp:$opCode)(${args.head}, ${args.tail.head})")
@@ -236,28 +236,28 @@ class ExpressionCompiler(
 
       def handleLongResult(e1: LongExpressionResult, e2: LongExpressionResult): ExpressionResult = {
         opCode match {
-          case Add => AddLongs(e1.apply, e2.apply)
-          case Sub => SubLongs(e1.apply, e2.apply)
-          case Mul => MulLongs(e1.apply, e2.apply)
-          case Div => DivLongs(e1.apply, e2.apply)
-          case Rem => RemLongs(e1.apply, e2.apply)
+          case Add => AddLongs(e1.apply _, e2.apply _)
+          case Sub => SubLongs(e1.apply _, e2.apply _)
+          case Mul => MulLongs(e1.apply _, e2.apply _)
+          case Div => DivLongs(e1.apply _, e2.apply _)
+          case Rem => RemLongs(e1.apply _, e2.apply _)
 
-          case Eq  => EqLongs(e1.apply, e2.apply)
-          case Neq => NeqLongs(e1.apply, e2.apply)
-          case Lt  => LtLongs(e1.apply, e2.apply)
-          case Leq => LeqLongs(e1.apply, e2.apply)
-          case Gt  => GtLongs(e1.apply, e2.apply)
-          case Geq => GeqLongs(e1.apply, e2.apply)
+          case Eq  => EqLongs(e1.apply _, e2.apply _)
+          case Neq => NeqLongs(e1.apply _, e2.apply _)
+          case Lt  => LtLongs(e1.apply _, e2.apply _)
+          case Leq => LeqLongs(e1.apply _, e2.apply _)
+          case Gt  => GtLongs(e1.apply _, e2.apply _)
+          case Geq => GeqLongs(e1.apply _, e2.apply _)
 
-          case Dshl => DshlLongs(e1.apply, e2.apply)
-          case Dshr => DshrLongs(e1.apply, e2.apply)
+          case Dshl => DshlLongs(e1.apply _, e2.apply _)
+          case Dshr => DshrLongs(e1.apply _, e2.apply _)
 
-          case And  => AndLongs(e1.apply, e2.apply, arg1Width.max(arg2Width))
-          case Or   => OrLongs(e1.apply, e2.apply, arg1Width.max(arg2Width))
-          case Xor  => XorLongs(e1.apply, e2.apply, arg1Width.max(arg2Width))
+          case And  => AndLongs(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
+          case Or   => OrLongs(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
+          case Xor  => XorLongs(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
 
           case Cat =>
-            CatLongs(e1.apply, arg1Width, e2.apply, arg2Width)
+            CatLongs(e1.apply _, arg1Width, e2.apply _, arg2Width)
 
           case _ =>
             throw TreadleException(s"Error:BinaryOp:$opCode(${args.head}, ${args.tail.head})")
@@ -266,28 +266,28 @@ class ExpressionCompiler(
 
       def handleBigResult(e1: BigExpressionResult, e2: BigExpressionResult): ExpressionResult = {
         opCode match {
-          case Add => AddBigs(e1.apply, e2.apply)
-          case Sub => SubBigs(e1.apply, e2.apply)
-          case Mul => MulBigs(e1.apply, e2.apply)
-          case Div => DivBigs(e1.apply, e2.apply)
-          case Rem => RemBigs(e1.apply, e2.apply)
+          case Add => AddBigs(e1.apply _, e2.apply _)
+          case Sub => SubBigs(e1.apply _, e2.apply _)
+          case Mul => MulBigs(e1.apply _, e2.apply _)
+          case Div => DivBigs(e1.apply _, e2.apply _)
+          case Rem => RemBigs(e1.apply _, e2.apply _)
 
-          case Eq  => EqBigs(e1.apply, e2.apply)
-          case Neq => NeqBigs(e1.apply, e2.apply)
-          case Lt  => LtBigs(e1.apply, e2.apply)
-          case Leq => LeqBigs(e1.apply, e2.apply)
-          case Gt  => GtBigs(e1.apply, e2.apply)
-          case Geq => GeqBigs(e1.apply, e2.apply)
+          case Eq  => EqBigs(e1.apply _, e2.apply _)
+          case Neq => NeqBigs(e1.apply _, e2.apply _)
+          case Lt  => LtBigs(e1.apply _, e2.apply _)
+          case Leq => LeqBigs(e1.apply _, e2.apply _)
+          case Gt  => GtBigs(e1.apply _, e2.apply _)
+          case Geq => GeqBigs(e1.apply _, e2.apply _)
 
-          case Dshl => DshlBigs(e1.apply, e2.apply)
-          case Dshr => DshrBigs(e1.apply, e2.apply)
+          case Dshl => DshlBigs(e1.apply _, e2.apply _)
+          case Dshr => DshrBigs(e1.apply _, e2.apply _)
 
-          case And  => AndBigs(e1.apply, e2.apply, arg1Width.max(arg2Width))
-          case Or   => OrBigs(e1.apply, e2.apply, arg1Width.max(arg2Width))
-          case Xor  => XorBigs(e1.apply, e2.apply, arg1Width.max(arg2Width))
+          case And  => AndBigs(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
+          case Or   => OrBigs(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
+          case Xor  => XorBigs(e1.apply _, e2.apply _, arg1Width.max(arg2Width))
 
           case Cat =>
-            CatBigs(e1.apply, arg1Width, e2.apply, arg2Width)
+            CatBigs(e1.apply _, arg1Width, e2.apply _, arg2Width)
 
           case _ =>
             throw TreadleException(s"Error:BinaryOp:$opCode(${args.head}, ${args.tail.head})")
@@ -300,21 +300,21 @@ class ExpressionCompiler(
           handleIntResult(e1, e2)
 
         case (IntSize, e1: LongExpressionResult, e2: IntExpressionResult) =>
-          handleLongResult(e1, ToLong(e2.apply))
+          handleLongResult(e1, ToLong(e2.apply _))
         case (IntSize, e1: BigExpressionResult, e2: IntExpressionResult) =>
-          handleBigResult(e1, ToBig(e2.apply))
+          handleBigResult(e1, ToBig(e2.apply _))
 
         case (IntSize, e1: IntExpressionResult, e2: LongExpressionResult) =>
-          handleLongResult(ToLong(e1.apply), e2)
+          handleLongResult(ToLong(e1.apply _), e2)
         case (IntSize, e1: LongExpressionResult, e2: LongExpressionResult) =>
           handleLongResult(e1, e2)
         case (IntSize, e1: BigExpressionResult, e2: LongExpressionResult) =>
-          handleBigResult(e1, LongToBig(e2.apply))
+          handleBigResult(e1, LongToBig(e2.apply _))
 
         case (IntSize, e1: IntExpressionResult, e2: BigExpressionResult) =>
-          handleBigResult(ToBig(e1.apply), e2)
+          handleBigResult(ToBig(e1.apply _), e2)
         case (IntSize, e1: LongExpressionResult, e2: BigExpressionResult) =>
-          handleBigResult(LongToBig(e1.apply), e2)
+          handleBigResult(LongToBig(e1.apply _), e2)
         case (IntSize, e1: BigExpressionResult, e2: BigExpressionResult) =>
           handleBigResult(e1, e2)
         case (IntSize, _, _) =>
@@ -322,23 +322,23 @@ class ExpressionCompiler(
             s"Error:BinaryOp:$opCode(${args.head}, ${args.tail.head}) ($arg1, $arg2)")
 
         case (LongSize, e1: IntExpressionResult, e2: IntExpressionResult) =>
-          handleLongResult(ToLong(e1.apply), ToLong(e2.apply))
+          handleLongResult(ToLong(e1.apply _), ToLong(e2.apply _))
         case (LongSize, e1: LongExpressionResult, e2: IntExpressionResult) =>
-          handleLongResult(e1, ToLong(e2.apply))
+          handleLongResult(e1, ToLong(e2.apply _))
         case (LongSize, e1: BigExpressionResult, e2: IntExpressionResult) =>
-          handleBigResult(e1, ToBig(e2.apply))
+          handleBigResult(e1, ToBig(e2.apply _))
 
         case (LongSize, e1: IntExpressionResult, e2: LongExpressionResult) =>
-          handleLongResult(ToLong(e1.apply), e2)
+          handleLongResult(ToLong(e1.apply _), e2)
         case (LongSize, e1: LongExpressionResult, e2: LongExpressionResult) =>
           handleLongResult(e1, e2)
         case (LongSize, e1: BigExpressionResult, e2: LongExpressionResult) =>
-          handleBigResult(e1, LongToBig(e2.apply))
+          handleBigResult(e1, LongToBig(e2.apply _))
 
         case (LongSize, e1: IntExpressionResult, e2: BigExpressionResult) =>
-          handleBigResult(ToBig(e1.apply), e2)
+          handleBigResult(ToBig(e1.apply _), e2)
         case (LongSize, e1: LongExpressionResult, e2: BigExpressionResult) =>
-          handleBigResult(LongToBig(e1.apply), e2)
+          handleBigResult(LongToBig(e1.apply _), e2)
         case (LongSize, e1: BigExpressionResult, e2: BigExpressionResult) =>
           handleBigResult(e1, e2)
         case (LongSize, _, _) =>
@@ -346,23 +346,23 @@ class ExpressionCompiler(
             s"Error:BinaryOp:$opCode(${args.head}, ${args.tail.head}) ($arg1, $arg2)")
 
         case (BigSize, e1: IntExpressionResult, e2: IntExpressionResult) =>
-          handleBigResult(ToBig(e1.apply), ToBig(e2.apply))
+          handleBigResult(ToBig(e1.apply _), ToBig(e2.apply _))
         case (BigSize, e1: LongExpressionResult, e2: IntExpressionResult) =>
-          handleBigResult(LongToBig(e1.apply), ToBig(e2.apply))
+          handleBigResult(LongToBig(e1.apply _), ToBig(e2.apply _))
         case (BigSize, e1: BigExpressionResult, e2: IntExpressionResult) =>
-          handleBigResult(e1, ToBig(e2.apply))
+          handleBigResult(e1, ToBig(e2.apply _))
 
         case (BigSize, e1: IntExpressionResult, e2: LongExpressionResult) =>
-          handleBigResult(ToBig(e1.apply), LongToBig(e2.apply))
+          handleBigResult(ToBig(e1.apply _), LongToBig(e2.apply _))
         case (BigSize, e1: LongExpressionResult, e2: LongExpressionResult) =>
-          handleBigResult(LongToBig(e1.apply), LongToBig(e2.apply))
+          handleBigResult(LongToBig(e1.apply _), LongToBig(e2.apply _))
         case (BigSize, e1: BigExpressionResult, e2: LongExpressionResult) =>
-          handleBigResult(e1, LongToBig(e2.apply))
+          handleBigResult(e1, LongToBig(e2.apply _))
 
         case (BigSize, e1: IntExpressionResult, e2: BigExpressionResult) =>
-          handleBigResult(ToBig(e1.apply), e2)
+          handleBigResult(ToBig(e1.apply _), e2)
         case (BigSize, e1: LongExpressionResult, e2: BigExpressionResult) =>
-          handleBigResult(LongToBig(e1.apply), e2)
+          handleBigResult(LongToBig(e1.apply _), e2)
         case (BigSize, e1: BigExpressionResult, e2: BigExpressionResult) =>
           handleBigResult(e1, e2)
 
@@ -389,24 +389,24 @@ class ExpressionCompiler(
       arg1 match {
         case e1: IntExpressionResult =>
           op match {
-            case Head => HeadInts(e1.apply, takeBits = param1, arg1Width)
-            case Tail => TailInts(e1.apply, toDrop = param1, arg1Width)
-            case Shl  => ShlInts(e1.apply, GetIntConstant(param1).apply)
-            case Shr  => ShrInts(e1.apply, GetIntConstant(param1).apply)
+            case Head => HeadInts(e1.apply _, takeBits = param1, arg1Width)
+            case Tail => TailInts(e1.apply _, toDrop = param1, arg1Width)
+            case Shl  => ShlInts(e1.apply _, GetIntConstant(param1).apply _)
+            case Shr  => ShrInts(e1.apply _, GetIntConstant(param1).apply _)
           }
         case e1: LongExpressionResult =>
           op match {
-            case Head => HeadLongs(e1.apply, takeBits = param1, arg1Width)
-            case Tail => TailLongs(e1.apply, toDrop = param1, arg1Width)
-            case Shl  => ShlLongs(e1.apply, GetLongConstant(param1).apply)
-            case Shr  => ShrLongs(e1.apply, GetLongConstant(param1).apply)
+            case Head => HeadLongs(e1.apply _, takeBits = param1, arg1Width)
+            case Tail => TailLongs(e1.apply _, toDrop = param1, arg1Width)
+            case Shl  => ShlLongs(e1.apply _, GetLongConstant(param1).apply _)
+            case Shr  => ShrLongs(e1.apply _, GetLongConstant(param1).apply _)
           }
         case e1: BigExpressionResult =>
           op match {
-            case Head => HeadBigs(e1.apply, takeBits = param1, arg1Width)
-            case Tail => TailBigs(e1.apply, toDrop = param1, arg1Width)
-            case Shl  => ShlBigs(e1.apply, GetBigConstant(param1).apply)
-            case Shr  => ShrBigs(e1.apply, GetBigConstant(param1).apply)
+            case Head => HeadBigs(e1.apply _, takeBits = param1, arg1Width)
+            case Tail => TailBigs(e1.apply _, toDrop = param1, arg1Width)
+            case Shl  => ShlBigs(e1.apply _, GetBigConstant(param1).apply _)
+            case Shr  => ShrBigs(e1.apply _, GetBigConstant(param1).apply _)
           }
       }
     }
@@ -428,15 +428,15 @@ class ExpressionCompiler(
       arg1 match {
         case e1: IntExpressionResult =>
           op match {
-            case Bits => BitsInts(e1.apply, arg2.toInt, arg3.toInt, width)
+            case Bits => BitsInts(e1.apply _, arg2.toInt, arg3.toInt, width)
           }
         case e1: LongExpressionResult =>
           op match {
-            case Bits => BitsLongs(e1.apply, arg2.toInt, arg3.toInt, width)
+            case Bits => BitsLongs(e1.apply _, arg2.toInt, arg3.toInt, width)
           }
         case e1: BigExpressionResult =>
           op match {
-            case Bits => BitsBigs(e1.apply, arg2.toInt, arg3.toInt, width)
+            case Bits => BitsBigs(e1.apply _, arg2.toInt, arg3.toInt, width)
           }
       }
     }
@@ -461,50 +461,50 @@ class ExpressionCompiler(
         case e1: IntExpressionResult =>
           op match {
             case Pad            => e1
-            case AsUInt         => AsUIntInts(e1.apply, width)
-            case AsSInt         => AsSIntInts(e1.apply, width)
+            case AsUInt         => AsUIntInts(e1.apply _, width)
+            case AsSInt         => AsSIntInts(e1.apply _, width)
             case AsClock        => e1
             case AsAsyncReset   => e1
 
             case Cvt            => e1
-            case Neg            => NegInts(e1.apply)
-            case Not            => NotInts(e1.apply, width)
+            case Neg            => NegInts(e1.apply _)
+            case Not            => NotInts(e1.apply _, width)
 
-            case Andr           => AndrInts(e1.apply, sourceWidth)
-            case Orr            => OrrInts(e1.apply,  sourceWidth)
-            case Xorr           => XorrInts(e1.apply, sourceWidth)
+            case Andr           => AndrInts(e1.apply _, sourceWidth)
+            case Orr            => OrrInts(e1.apply _,  sourceWidth)
+            case Xorr           => XorrInts(e1.apply _, sourceWidth)
           }
         case e1: LongExpressionResult =>
           op match {
             case Pad            => e1
-            case AsUInt         => AsUIntLongs(e1.apply, width)
-            case AsSInt         => AsSIntLongs(e1.apply, width)
+            case AsUInt         => AsUIntLongs(e1.apply _, width)
+            case AsSInt         => AsSIntLongs(e1.apply _, width)
             case AsClock        => e1
             case AsAsyncReset   => e1
 
             case Cvt            => e1
-            case Neg            => NegLongs(e1.apply)
-            case Not            => NotLongs(e1.apply, width)
+            case Neg            => NegLongs(e1.apply _)
+            case Not            => NotLongs(e1.apply _, width)
 
-            case Andr           => AndrLongs(e1.apply, sourceWidth)
-            case Orr            => OrrLongs(e1.apply,  sourceWidth)
-            case Xorr           => XorrLongs(e1.apply, sourceWidth)
+            case Andr           => AndrLongs(e1.apply _, sourceWidth)
+            case Orr            => OrrLongs(e1.apply _,  sourceWidth)
+            case Xorr           => XorrLongs(e1.apply _, sourceWidth)
           }
         case e1: BigExpressionResult =>
           op match {
             case Pad            => e1
-            case AsUInt         => AsUIntBigs(e1.apply, width)
-            case AsSInt         => AsSIntBigs(e1.apply, width)
+            case AsUInt         => AsUIntBigs(e1.apply _, width)
+            case AsSInt         => AsSIntBigs(e1.apply _, width)
             case AsClock        => e1
             case AsAsyncReset   => e1
 
             case Cvt            => e1
-            case Neg            => NegBigs(e1.apply)
-            case Not            => NotBigs(e1.apply, width)
+            case Neg            => NegBigs(e1.apply _)
+            case Not            => NotBigs(e1.apply _, width)
 
-            case Andr           => AndrBigs(e1.apply, sourceWidth)
-            case Orr            => OrrBigs(e1.apply,  sourceWidth)
-            case Xorr           => XorrBigs(e1.apply, sourceWidth)
+            case Andr           => AndrBigs(e1.apply _, sourceWidth)
+            case Orr            => OrrBigs(e1.apply _,  sourceWidth)
+            case Xorr           => XorrBigs(e1.apply _, sourceWidth)
           }
       }
     }
@@ -520,25 +520,25 @@ class ExpressionCompiler(
           (trueExpression, falseExpression) match {
 
             case (t: IntExpressionResult, f: IntExpressionResult) =>
-              MuxInts(c.apply, t.apply, f.apply)
+              MuxInts(c.apply _, t.apply _, f.apply _)
             case (t: IntExpressionResult, f: LongExpressionResult) =>
-              MuxLongs(c.apply, ToLong(t.apply).apply, f.apply)
+              MuxLongs(c.apply _, ToLong(t.apply _).apply _, f.apply _)
             case (t: IntExpressionResult, f: BigExpressionResult) =>
-              MuxBigs(c.apply, ToBig(t.apply).apply, f.apply)
+              MuxBigs(c.apply _, ToBig(t.apply _).apply _, f.apply _)
 
             case (t: LongExpressionResult, f: IntExpressionResult) =>
-              MuxLongs(c.apply, t.apply, ToLong(f.apply).apply)
+              MuxLongs(c.apply _, t.apply _, ToLong(f.apply _).apply _)
             case (t: LongExpressionResult, f: LongExpressionResult) =>
-              MuxLongs(c.apply, t.apply, f.apply)
+              MuxLongs(c.apply _, t.apply _, f.apply _)
             case (t: LongExpressionResult, f: BigExpressionResult) =>
-              MuxBigs(c.apply, LongToBig(t.apply).apply, f.apply)
+              MuxBigs(c.apply _, LongToBig(t.apply _).apply _, f.apply _)
 
             case (t: BigExpressionResult, f: IntExpressionResult) =>
-              MuxBigs(c.apply, t.apply, ToBig(f.apply).apply)
+              MuxBigs(c.apply _, t.apply _, ToBig(f.apply _).apply _)
             case (t: BigExpressionResult, f: LongExpressionResult) =>
-              MuxBigs(c.apply, t.apply, LongToBig(f.apply).apply)
+              MuxBigs(c.apply _, t.apply _, LongToBig(f.apply _).apply _)
             case (t: BigExpressionResult, f: BigExpressionResult) =>
-              MuxBigs(c.apply, t.apply, f.apply)
+              MuxBigs(c.apply _, t.apply _, f.apply _)
 
             case (a, b) =>
               throw TreadleException(s"Unhandled Mux($condition, $a, $b)")
@@ -575,11 +575,11 @@ class ExpressionCompiler(
               case c: IntExpressionResult =>
                 processExpression(value) match {
                   case t: IntExpressionResult =>
-                    MuxInts(c.apply, t.apply, UndefinedInts(getWidth(tpe)).apply)
+                    MuxInts(c.apply _, t.apply _, UndefinedInts(getWidth(tpe)).apply _)
                   case t: LongExpressionResult =>
-                    MuxLongs(c.apply, t.apply, UndefinedLongs(getWidth(tpe)).apply)
+                    MuxLongs(c.apply _, t.apply _, UndefinedLongs(getWidth(tpe)).apply _)
                   case t: BigExpressionResult =>
-                    MuxBigs(c.apply, t.apply, UndefinedBigs(getWidth(tpe)).apply)
+                    MuxBigs(c.apply _, t.apply _, UndefinedBigs(getWidth(tpe)).apply _)
                   case _ =>
                     throw TreadleException(s"Mux condition is not 1 bit $condition parsed as $c")
                 }
@@ -689,7 +689,7 @@ class ExpressionCompiler(
             //
             val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(assignedSymbol))
             val prevClockAssigner = dataStore.AssignInt(
-              prevClockSymbol, makeGet(assignedSymbol).asInstanceOf[IntExpressionResult].apply, info = con.info
+              prevClockSymbol, makeGet(assignedSymbol).asInstanceOf[IntExpressionResult].apply _, info = con.info
             )
             scheduler.addEndOfCycleAssigner(prevClockAssigner)
           }
@@ -758,7 +758,7 @@ class ExpressionCompiler(
           //
           val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(symbol))
           val prevClockAssigner = dataStore.AssignInt(
-            prevClockSymbol, makeGet(symbol).asInstanceOf[IntExpressionResult].apply, info
+            prevClockSymbol, makeGet(symbol).asInstanceOf[IntExpressionResult].apply _, info
           )
           scheduler.addEndOfCycleAssigner(prevClockAssigner)
         }
@@ -779,9 +779,9 @@ class ExpressionCompiler(
 
             val clockValue     = dataStore.GetInt(clockSymbol.index)
             val prevClockValue = dataStore.GetInt(prevClockSymbol.index)
-            val clockHigh   = GtInts(clockValue.apply, GetIntConstant(0).apply)
-            val clockWasLow = EqInts(prevClockValue.apply, GetIntConstant(0).apply)
-            val isPosEdge   = AndInts(clockHigh.apply, clockWasLow.apply, 1)
+            val clockHigh   = GtInts(clockValue.apply _, GetIntConstant(0).apply _)
+            val clockWasLow = EqInts(prevClockValue.apply _, GetIntConstant(0).apply _)
+            val isPosEdge   = AndInts(clockHigh.apply _, clockWasLow.apply _, 1)
 
             val posEdgeMux = processMux(isPosEdge, makeGet(registerIn), makeGet(registerOut))
 
@@ -791,7 +791,7 @@ class ExpressionCompiler(
                 case _ =>
                   throw TreadleException(s"reset expression at $info, was not UInt<1>")
               }
-              val asyncResetCondition = GtInts(resetValue.apply, GetIntConstant(0).apply)
+              val asyncResetCondition = GtInts(resetValue.apply _, GetIntConstant(0).apply _)
               val asyncResetMux = processMux(asyncResetCondition, processExpression(initExpression), posEdgeMux)
 
               makeAssigner(registerOut, asyncResetMux, info = info)
@@ -821,8 +821,8 @@ class ExpressionCompiler(
           case Some(stopInfo) =>
             val intExpression = processExpression(enableExpression) match {
               case i : IntExpressionResult  => i
-              case l : LongExpressionResult => LongToInt(l.apply)
-              case b : BigExpressionResult  => ToInt(b.apply)
+              case l : LongExpressionResult => LongToInt(l.apply _)
+              case b : BigExpressionResult  => ToInt(b.apply _)
               case _ =>
                 throw TreadleException(s"Error: stop $stop has unknown condition type")
             }
@@ -856,8 +856,8 @@ class ExpressionCompiler(
           case Some(printInfo) =>
             val intExpression = processExpression(enableExpression) match {
               case i : IntExpressionResult  => i
-              case l : LongExpressionResult => LongToInt(l.apply)
-              case b : BigExpressionResult  => ToInt(b.apply)
+              case l : LongExpressionResult => LongToInt(l.apply _)
+              case b : BigExpressionResult  => ToInt(b.apply _)
               case _ =>
                 throw TreadleException(s"Error: printf $printf has unknown condition type")
             }
@@ -901,7 +901,7 @@ class ExpressionCompiler(
         val clockSymbol = symbolTable(port.name)
         val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
         val prevClockAssigner = dataStore.AssignInt(
-          prevClockSymbol, makeGet(clockSymbol).asInstanceOf[IntExpressionResult].apply, info = NoInfo
+          prevClockSymbol, makeGet(clockSymbol).asInstanceOf[IntExpressionResult].apply _, info = NoInfo
         )
         scheduler.addEndOfCycleAssigner(prevClockAssigner)
       }

--- a/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
+++ b/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
@@ -14,7 +14,6 @@ import scala.collection.mutable
 //noinspection ScalaUnusedSymbol
 class ExpressionViewBuilder(
     symbolTable: SymbolTable,
-    dataStore: DataStore,
     scheduler: Scheduler,
     validIfIsRandom: Boolean,
     blackBoxFactories: Seq[ScalaBlackBoxFactory]
@@ -344,13 +343,12 @@ object ExpressionViewBuilder {
 
   def getExpressionViews(
       symbolTable: SymbolTable,
-      dataStore: DataStore,
       scheduler: Scheduler,
       validIfIsRandom: Boolean,
       circuit: Circuit,
       blackBoxFactories: Seq[ScalaBlackBoxFactory]): Map[Symbol, ExpressionView] = {
     val builder = new ExpressionViewBuilder(
-      symbolTable, dataStore, scheduler, validIfIsRandom, blackBoxFactories)
+      symbolTable, scheduler, validIfIsRandom, blackBoxFactories)
     builder.compile(circuit, blackBoxFactories)
     builder.expressionViews.toMap
   }

--- a/src/main/scala/treadle/executable/Memory.scala
+++ b/src/main/scala/treadle/executable/Memory.scala
@@ -386,7 +386,7 @@ object Memory {
     * @param compiler     needed for assigner generation
     */
   def buildMemoryInternals(
-    memory: DefMemory, expandedName: String, scheduler: Scheduler, compiler: ExpressionCompiler
+    memory: DefMemory, expandedName: String, scheduler: Scheduler, compiler: AbstractExpressionCompiler
   ): Unit = {
     val symbolTable  = scheduler.symbolTable
     val memorySymbol = symbolTable(expandedName)
@@ -536,8 +536,8 @@ object Memory {
       compiler.makeIndirectAssigner(
         portSymbol,
         memorySymbol,
-        memoryIndex      = endOfAddrPipeline.index,
-        enableIndex      = endOfValidPipeline.index,
+        addr             = endOfAddrPipeline,
+        enable           = endOfValidPipeline,
         expressionResult = compiler.makeGet(endOfDataPipeline),
         clock,
         memory.info
@@ -581,8 +581,8 @@ object Memory {
       compiler.makeIndirectAssigner(
         portSymbol,
         memorySymbol,
-        endOfAddrPipeline.index,
-        endOfValidPipeline.index,
+        endOfAddrPipeline,
+        endOfValidPipeline,
         compiler.makeGet(endOfDataPipeline),
         clock,
         info = memory.info

--- a/src/main/scala/treadle/executable/Memory.scala
+++ b/src/main/scala/treadle/executable/Memory.scala
@@ -390,7 +390,6 @@ object Memory {
   ): Unit = {
     val symbolTable  = scheduler.symbolTable
     val memorySymbol = symbolTable(expandedName)
-    val dataStore    = compiler.dataStore
 
     /*
       * construct a pipeline of registers based on the latency
@@ -527,8 +526,8 @@ object Memory {
       val valid  = symbolTable(s"$writerName.valid")
 
       // compute a valid so we only have to carry a single boolean up the write queue
-      compiler.makeAssigner(
-        valid, AndInts(dataStore.GetInt(enable.index).apply _, dataStore.GetInt(mask.index).apply _, 1), info = memory.info)
+      compiler.makeAssigner(valid, compiler.makeAnd(compiler.makeGet(enable), compiler.makeGet(mask), 1),
+        info = memory.info)
 
       val endOfValidPipeline = buildWritePipelineAssigners(clock, valid, writerName, "valid")
       val endOfAddrPipeline  = buildWritePipelineAssigners(clock, addr, writerName, "addr")
@@ -570,11 +569,8 @@ object Memory {
       // compute a valid so we only have to carry a single boolean up the write queue
       compiler.makeAssigner(
         valid,
-        AndInts(
-          AndInts(dataStore.GetInt(enable.index).apply _, dataStore.GetInt(mask.index).apply _, 1).apply _,
-          dataStore.GetInt(mode.index).apply _,
-          1
-        ),
+        compiler.makeAnd(compiler.makeAnd(compiler.makeGet(enable), compiler.makeGet(mask), 1),
+          compiler.makeGet(mode), 1),
         info = memory.info
       )
 

--- a/src/main/scala/treadle/executable/Memory.scala
+++ b/src/main/scala/treadle/executable/Memory.scala
@@ -528,7 +528,7 @@ object Memory {
 
       // compute a valid so we only have to carry a single boolean up the write queue
       compiler.makeAssigner(
-        valid, AndInts(dataStore.GetInt(enable.index).apply, dataStore.GetInt(mask.index).apply, 1), info = memory.info)
+        valid, AndInts(dataStore.GetInt(enable.index).apply _, dataStore.GetInt(mask.index).apply _, 1), info = memory.info)
 
       val endOfValidPipeline = buildWritePipelineAssigners(clock, valid, writerName, "valid")
       val endOfAddrPipeline  = buildWritePipelineAssigners(clock, addr, writerName, "addr")
@@ -571,8 +571,8 @@ object Memory {
       compiler.makeAssigner(
         valid,
         AndInts(
-          AndInts(dataStore.GetInt(enable.index).apply, dataStore.GetInt(mask.index).apply, 1).apply,
-          dataStore.GetInt(mode.index).apply,
+          AndInts(dataStore.GetInt(enable.index).apply _, dataStore.GetInt(mask.index).apply _, 1).apply _,
+          dataStore.GetInt(mode.index).apply _,
           1
         ),
         info = memory.info

--- a/src/main/scala/treadle/executable/PrintfOp.scala
+++ b/src/main/scala/treadle/executable/PrintfOp.scala
@@ -10,7 +10,7 @@ case class PrintfOp(
   info            : Info,
   string          : StringLit,
   args            : Seq[ExpressionResult],
-  clockTransition : ClockTransitionGetter,
+  clockTransition : AbstractClockTransitionGetter,
   condition       : IntExpressionResult
 ) extends Assigner {
 

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -38,7 +38,7 @@ object SymbolAtDepth {
   * @param expressionViews  expression information
   */
 class ExpressionViewRenderer(
-  dataStore:          DataStore,
+  dataStore:          AbstractDataStore,
   symbolTable:        SymbolTable,
   expressionViews:    Map[Symbol, ExpressionView],
   maxDependencyDepth: Int = 8
@@ -198,12 +198,10 @@ class ExpressionViewRenderer(
             val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
             val prevClockIndex = prevClockSymbol.index
 
-            dataStore
-                    .rollBackBufferManager
-                    .findBufferBeforeClockTransition(dataTime, clockIndex, prevClockIndex) match {
+            dataStore.findBufferBeforeClockTransition(dataTime, clockIndex, prevClockIndex) match {
 
               case Some(buffer) =>
-                builder ++= renderView(view, symbolAtDepth.displayDepth, buffer.time, buffer)
+                builder ++= renderView(view, symbolAtDepth.displayDepth, buffer.getTime, buffer)
 
               case _ =>
             }

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -139,7 +139,7 @@ class ExpressionViewRenderer(
             }
           }
 
-          val value = symbol.normalize(dataArrays.getValueAtIndex(symbol.dataSize, symbol.index))
+          val value = symbol.normalize(dataArrays(symbol))
 
           val string = s"${symbol.name}" + (if(showValues) {
              " <= " +
@@ -181,7 +181,7 @@ class ExpressionViewRenderer(
             if (dataTime < startTime) {
               builder ++= Console.RED
             }
-            val currentValue = symbol.normalize(symbolAtDepth.dataArrays.getValueAtIndex(symbol.dataSize, symbol.index))
+            val currentValue = symbol.normalize(symbolAtDepth.dataArrays(symbol))
             builder ++= s"${formatOutput(currentValue)} : "
             if (dataTime < startTime) {
               builder ++= Console.RESET

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -17,10 +17,10 @@ object RenderHelper {
 
 class ExpressionView(val sc: StringContext, val args: Seq[Any])
 
-class SymbolAtDepth(val symbol: Symbol, val displayDepth: Int, val dataTime: Long, val dataArrays: HasDataArrays)
+class SymbolAtDepth(val symbol: Symbol, val displayDepth: Int, val dataTime: Long, val dataArrays: DataReader)
 
 object SymbolAtDepth {
-  def apply(symbol: Symbol, displayDepth: Int, dataTime: Long, dataArrays: HasDataArrays): SymbolAtDepth = {
+  def apply(symbol: Symbol, displayDepth: Int, dataTime: Long, dataArrays: DataReader): SymbolAtDepth = {
     new SymbolAtDepth(symbol, displayDepth, dataTime, dataArrays)
   }
 }
@@ -66,7 +66,7 @@ class ExpressionViewRenderer(
       }
     }
 
-    def renderView(view: ExpressionView, displayDepth: Int, dataTime: Long, dataArrays: HasDataArrays): String = {
+    def renderView(view: ExpressionView, displayDepth: Int, dataTime: Long, dataArrays: DataReader): String = {
       val builder = new StringBuilder()
 
       val sc = view.sc

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -194,11 +194,9 @@ class ExpressionViewRenderer(
           // If not showing values then just don't worry about previous rollback buffer
           if(symbolTable.isRegister(symbol.name) && showValues) {
             val clockSymbol = symbolTable.registerToClock(symbol)
-            val clockIndex  = clockSymbol.index
             val prevClockSymbol = symbolTable(SymbolTable.makePreviousValue(clockSymbol))
-            val prevClockIndex = prevClockSymbol.index
 
-            dataStore.findBufferBeforeClockTransition(dataTime, clockIndex, prevClockIndex) match {
+            dataStore.findBufferBeforeClockTransition(dataTime, clockSymbol, prevClockSymbol) match {
 
               case Some(buffer) =>
                 builder ++= renderView(view, symbolAtDepth.displayDepth, buffer.getTime, buffer)

--- a/src/main/scala/treadle/executable/StopOp.scala
+++ b/src/main/scala/treadle/executable/StopOp.scala
@@ -10,7 +10,7 @@ case class StopOp(
   returnValue        : Int,
   condition          : IntExpressionResult,
   hasStopped         : Symbol,
-  dataStore          : DataStore,
+  dataStore          : DataWriter,
   clockTransition    : ClockTransitionGetter
 ) extends Assigner {
 
@@ -20,7 +20,7 @@ case class StopOp(
       if (isVerbose) {
         println(s"clock ${symbol.name} has fired")
       }
-      dataStore(hasStopped) = returnValue + 1
+      dataStore.update(hasStopped, returnValue + 1)
     }
 
     () => Unit

--- a/src/main/scala/treadle/executable/StopOp.scala
+++ b/src/main/scala/treadle/executable/StopOp.scala
@@ -11,7 +11,7 @@ case class StopOp(
   condition          : IntExpressionResult,
   hasStopped         : Symbol,
   dataStore          : DataWriter,
-  clockTransition    : ClockTransitionGetter
+  clockTransition    : AbstractClockTransitionGetter
 ) extends Assigner {
 
   def run: FuncUnit = {

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -27,10 +27,8 @@ class SymbolTable(val nameToSymbol: mutable.HashMap[String, Symbol]) {
     toBlackBoxImplementation(symbol) = blackBoxImplementation
   }
 
-  def allocateData(dataStoreAllocator: DataStoreAllocator): Unit = {
-    nameToSymbol.values.foreach { symbol =>
-      symbol.index = dataStoreAllocator.getIndex(symbol.dataSize, symbol.slots)
-    }
+  def allocateData(getIndex: Symbol => Int): Unit = {
+    nameToSymbol.values.foreach { symbol => symbol.index = getIndex(symbol) }
   }
 
   def size: Int = nameToSymbol.size
@@ -53,15 +51,6 @@ class SymbolTable(val nameToSymbol: mutable.HashMap[String, Symbol]) {
   def isTopLevelInput(name: String): Boolean = inputPortsNames.contains(name)
 
   def apply(name: String): Symbol = nameToSymbol(name)
-
-  def getSymbolFromGetter(expressionResult: ExpressionResult, dataStore: DataStore): Option[Symbol] = {
-    expressionResult match {
-      case dataStore.GetInt(index)  => symbols.find { symbol => symbol.dataSize == IntSize && symbol.index == index}
-      case dataStore.GetLong(index) => symbols.find { symbol => symbol.dataSize == LongSize && symbol.index == index}
-      case dataStore.GetBig(index)  => symbols.find { symbol => symbol.dataSize == BigSize && symbol.index == index}
-      case _ => None
-    }
-  }
 
   def findHighestClock(symbol: Symbol): Option[Symbol] = {
     parentsOf.getEdges(symbol).toList match {

--- a/src/main/scala/treadle/executable/Transition.scala
+++ b/src/main/scala/treadle/executable/Transition.scala
@@ -60,10 +60,10 @@ case class ClockBasedAssigner(
     }
   }
 
-  var run: FuncUnit = runLean
+  var run: FuncUnit = runLean _
 
   override def setLeanMode(isLean: Boolean): Unit = {
     assigner.setLeanMode(isLean)
-    run = if(isLean) runLean else runFull
+    run = if(isLean) runLean _ else runFull _
   }
 }

--- a/src/main/scala/treadle/stage/TreadleStage.scala
+++ b/src/main/scala/treadle/stage/TreadleStage.scala
@@ -29,7 +29,7 @@ object TreadleCompatibilityPhase extends Phase {
   def checkFormTransform(circuitForm: CircuitForm, annotations: AnnotationSeq): AnnotationSeq = {
     val phases = circuitForm match {
       case ChirrtlForm => chirrtlPhases
-      case LowForm => lowFIRRTLPhases
+      case _ => lowFIRRTLPhases
     }
     phases.foldLeft(annotations)( (a, f) => f.transform(a) )
   }

--- a/src/test/scala/treadle/CarryOrChain3.scala
+++ b/src/test/scala/treadle/CarryOrChain3.scala
@@ -2,7 +2,8 @@
 
 package treadle
 
-import org.scalatest.{Matchers, FreeSpec}
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.{FreeSpec, Matchers}
 
 class CarryOrChain3 extends FreeSpec with Matchers {
   private val input =
@@ -50,7 +51,7 @@ class CarryOrChain3 extends FreeSpec with Matchers {
       bin.toList.map( "01".indexOf(_)).map( BigInt(_)).reverse.toArray
     }
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     val lst = List( (v("001"),v("111")))
     for ( (a,co) <- lst) {

--- a/src/test/scala/treadle/CarryOrChain6.scala
+++ b/src/test/scala/treadle/CarryOrChain6.scala
@@ -2,7 +2,8 @@
 
 package treadle
 
-import org.scalatest.{Matchers, FreeSpec}
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.{FreeSpec, Matchers}
 
 class CarryOrChain6 extends FreeSpec with Matchers {
   private val input =
@@ -76,7 +77,7 @@ class CarryOrChain6 extends FreeSpec with Matchers {
       bin.toList.map( "01".indexOf(_)).map( BigInt(_)).reverse.toArray
     }
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     val lst = List( (v("000001"),v("111111")))
     for ( (a,co) <- lst) {

--- a/src/test/scala/treadle/ClockSpec.scala
+++ b/src/test/scala/treadle/ClockSpec.scala
@@ -93,17 +93,7 @@ class ClockSpec extends FreeSpec with Matchers {
         |    out1 <= m.read.data
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        vcdShowUnderscored = true,
-        showFirrtlAtLoad = false,
-        writeVCD = false,
-        validIfIsRandom = false
-      )
-    }
-
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), ValidIfIsRandomAnnotation))
 
     // load memory
     tester.poke("write_en", 1)

--- a/src/test/scala/treadle/DeepExecutionSpec.scala
+++ b/src/test/scala/treadle/DeepExecutionSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 
@@ -10,7 +11,7 @@ class DeepExecutionSpec extends FreeSpec with Matchers {
   "DeepExecutionSpec should pass a basic test" in {
     val stream = getClass.getResourceAsStream("/DeepExecution.fir")
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.step(100)
     tester.report()

--- a/src/test/scala/treadle/ExpressionRenderSpec.scala
+++ b/src/test/scala/treadle/ExpressionRenderSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 // scalastyle:off magic.number
@@ -31,18 +32,7 @@ class ExpressionRenderSpec extends FreeSpec with Matchers {
         |    out <= node0
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 0,
-        symbolsToWatch = Seq()
-      )
-    }
-
-    val t = TreadleTester(input, optionsManager)
+    val t = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
     t.poke("in0", 10)
     t.poke("in1", 11)
     t.poke("in2", 12)
@@ -82,18 +72,7 @@ class ExpressionRenderSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 10,
-        symbolsToWatch = Seq()
-      )
-    }
-
-    val t = TreadleTester(input, optionsManager)
+    val t = TreadleTester(Seq(FirrtlSourceAnnotation(input), RollBackBuffersAnnotation(10)))
     t.poke("in0", 1)
     t.step()
     t.poke("in0", 2)

--- a/src/test/scala/treadle/FailSpec.scala
+++ b/src/test/scala/treadle/FailSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FlatSpec, Matchers}
 
 class FailSpec extends FlatSpec with Matchers {
@@ -16,7 +17,7 @@ class FailSpec extends FlatSpec with Matchers {
         |    output c : Fixed
         |    c <= mul(a, b)""".stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.fail(3)
     tester.report()

--- a/src/test/scala/treadle/FixedPointDivide.scala
+++ b/src/test/scala/treadle/FixedPointDivide.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 
@@ -24,7 +25,7 @@ class FixedPointDivide extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.poke("io_in", 256)
     tester.expect("io_out", 64)
@@ -56,7 +57,7 @@ class SignedAdder extends FreeSpec with Matchers {
           |    io_out <= _T_7
         """.stripMargin
 
-        val tester = TreadleTester(input)
+        val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
         for {
           i <- BigIntTestValuesGenerator(extremaOfSIntOfWidth(bitWidth))
@@ -157,7 +158,7 @@ class DynamicShiftRight extends FreeSpec with Matchers {
           |
         """.stripMargin
 
-        val tester = TreadleTester(input)
+        val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
         val mask = BigInt("1" * bitWidth, 2)
 

--- a/src/test/scala/treadle/ForceValueSpec.scala
+++ b/src/test/scala/treadle/ForceValueSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 //scalastyle:off magic.number
@@ -42,12 +43,7 @@ class ForceValueSpec extends FreeSpec with Matchers {
   "force value operates on any internal wire" - {
     "no forces should work as expected" in {
 
-      val manager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
-      }
-
-      val tester = TreadleTester(simpleCircuit, manager)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(simpleCircuit)))
 
       val bigNum = BigInt("1" * 66, 2)
 
@@ -65,12 +61,7 @@ class ForceValueSpec extends FreeSpec with Matchers {
     }
     "force register should work" in {
 
-      val manager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          rollbackBuffers = 0, showFirrtlAtLoad = true, setVerbose = false, writeVCD = false)
-      }
-
-      val tester = TreadleTester(simpleCircuit, manager)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(simpleCircuit)))
 
       val bigNum = BigInt("1" * 66, 2)
 
@@ -90,12 +81,7 @@ class ForceValueSpec extends FreeSpec with Matchers {
     }
     "force wire should work" in {
 
-      val manager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          rollbackBuffers = 0, showFirrtlAtLoad = true, setVerbose = true, writeVCD = false)
-      }
-
-      val tester = TreadleTester(simpleCircuit, manager)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(simpleCircuit)))
 
       val bigNum = BigInt("1" * 66, 2)
 

--- a/src/test/scala/treadle/GCDTester.scala
+++ b/src/test/scala/treadle/GCDTester.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FlatSpec, Matchers}
 
 // scalastyle:off magic.number
@@ -57,25 +58,17 @@ class GCDTester extends FlatSpec with Matchers {
     """
         .stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
-    }
-
     val values =
       for {x <- 10 to 100
            y <- 10 to 100
       } yield (x, y, computeGcd(x, y)._1)
 
-    val tester = TreadleTester(gcdFirrtl, manager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(gcdFirrtl)))
 
     val startTime = System.nanoTime()
-    // engine.setVerbose()
     tester.poke("clock", 1)
 
-//    List((344, 17, 1)).foreach { case (x, y, z) =>
-      //    List((1, 1, 1), (34, 17, 17), (8, 12, 4)).foreach { case (x, y, z) =>
-          for((x, y, z) <- values) {
+    for((x, y, z) <- values) {
       tester.step()
       tester.poke("io_a", x)
       tester.poke("io_b", y)
@@ -138,20 +131,12 @@ class GCDTester extends FlatSpec with Matchers {
     """
         .stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        showFirrtlAtLoad = false,
-        setVerbose = false,
-        rollbackBuffers = 0
-      )
-    }
-
     val values =
       for {x <- 1 to 100
            y <- 1 to 100
       } yield (x, y, computeGcd(x, y)._1)
 
-    val tester = TreadleTester(gcdFirrtl, manager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(gcdFirrtl)))
 
     val startTime = System.nanoTime()
     tester.poke("clock", 1)

--- a/src/test/scala/treadle/InfoSpec.scala
+++ b/src/test/scala/treadle/InfoSpec.scala
@@ -3,6 +3,7 @@ package treadle
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.TreadleException
 
@@ -27,7 +28,7 @@ class InfoSpec extends FreeSpec with Matchers {
     val outputBuffer = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputBuffer)) {
 
-      val tester = TreadleTester(input)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
       tester.poke("in1", 7)
 
       try {

--- a/src/test/scala/treadle/ModuleInLineSpec.scala
+++ b/src/test/scala/treadle/ModuleInLineSpec.scala
@@ -2,7 +2,8 @@
 
 package treadle
 
-import org.scalatest.{Matchers, FlatSpec}
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.{FlatSpec, Matchers}
 
 class ModuleInLineSpec extends FlatSpec with Matchers {
   behavior of "multiple modes"
@@ -11,7 +12,7 @@ class ModuleInLineSpec extends FlatSpec with Matchers {
     val stream = getClass.getResourceAsStream("/three_deep.fir")
     val input = io.Source.fromInputStream(stream).mkString
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.engine.symbolTable.outputPortsNames.size should be > 0
   }
@@ -20,13 +21,7 @@ class ModuleInLineSpec extends FlatSpec with Matchers {
     val stream = getClass.getResourceAsStream("/NestedModsWithReg.fir")
     val input = io.Source.fromInputStream(stream).mkString
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        callResetAtStartUp = false
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.poke("in1", 3)
     tester.step()

--- a/src/test/scala/treadle/NativeAsyncResetSpec.scala
+++ b/src/test/scala/treadle/NativeAsyncResetSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 //scalastyle:off magic.number
@@ -30,11 +31,7 @@ class NativeAsyncResetSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
-    }
-    val tester = TreadleTester(firrtlSource, manager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(firrtlSource)))
 
     tester.poke("in", 7)
     tester.expect("out_reg", 0)
@@ -93,11 +90,7 @@ class NativeAsyncResetSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
-    }
-    val tester = TreadleTester(firrtlSource, manager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(firrtlSource)))
 
     tester.poke("in", 7)
     tester.expect("out_reg", 0)

--- a/src/test/scala/treadle/OutputAsSourceSpec.scala
+++ b/src/test/scala/treadle/OutputAsSourceSpec.scala
@@ -2,7 +2,8 @@
 
 package treadle
 
-import org.scalatest.{Matchers, FreeSpec}
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.{FreeSpec, Matchers}
 
 class OutputAsSourceSpec extends FreeSpec with Matchers {
   "it must be possible for the engine to handle module outputs as rhs dependencies" in {
@@ -20,8 +21,7 @@ class OutputAsSourceSpec extends FreeSpec with Matchers {
         |    out2 <= T_1
       """.stripMargin
 
-    val tester = TreadleTester(input)
-    // tester.setVerbose(true)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.poke("in1", 1)
 

--- a/src/test/scala/treadle/Performance.scala
+++ b/src/test/scala/treadle/Performance.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 /**
@@ -34,12 +35,7 @@ class Performance extends FreeSpec with Matchers {
     """
               .stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        rollbackBuffers = 0, showFirrtlAtLoad = false, setVerbose = false, writeVCD = false)
-    }
-
-    val tester = TreadleTester(junkFirrtl, manager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(junkFirrtl)))
 
     val startTime = System.nanoTime()
 

--- a/src/test/scala/treadle/PrintStopSpec.scala
+++ b/src/test/scala/treadle/PrintStopSpec.scala
@@ -3,6 +3,7 @@ package treadle
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FlatSpec, Matchers}
 import treadle.executable.StopException
 
@@ -19,8 +20,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
-
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
     for (cycle_number <- 0 to 10) {
       tester.step(2)
       tester.engine.stopped should be (false)
@@ -37,8 +37,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
-
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
     intercept[StopException] {
       tester.step(2)
     }
@@ -56,8 +55,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val tester = TreadleTester(input)
-
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
     intercept[StopException] {
       tester.step(2)
     }
@@ -80,13 +78,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
           |
       """.stripMargin
 
-      val manager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          showFirrtlAtLoad = false,
-          setVerbose = false
-        )
-      }
-      val tester = TreadleTester(input, manager)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
       tester.step(2)
       tester.finish
@@ -109,8 +101,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
           |
       """.stripMargin
 
-      val tester = TreadleTester(input)
-
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
       tester.step(2)
     }
 
@@ -133,8 +124,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
           |
         """.stripMargin
 
-      val tester = TreadleTester(input)
-
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
       tester.step(2)
     }
     output.toString().contains("char M int 7 hex ff SIint -2 111") should be (true)
@@ -163,7 +153,8 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
         """.stripMargin
 
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
     tester.poke("enable", 0)
     tester.poke("in1", 1)
     println("before peek")
@@ -229,16 +220,10 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        showFirrtlAtLoad = false
-      )
-    }
-
     val output = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(output)) {
-      val tester = TreadleTester(input, optionsManager)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
       tester.poke("io_in", 479)
       tester.step()
 
@@ -286,16 +271,10 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        showFirrtlAtLoad = false
-      )
-    }
-
     val output = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(output)) {
-      val tester = TreadleTester(input, optionsManager)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
       tester.poke("io_in", 479)
       tester.step()
 
@@ -337,16 +316,10 @@ class PrintStopSpec extends FlatSpec with Matchers {
         |    printf(clock, UInt<1>(1), "+++ r0=%d r1=%d\n", r0, r1) @[PrintfWrong.scala 19:11]
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        showFirrtlAtLoad = false
-      )
-    }
-
     val output = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(output)) {
-      val tester = TreadleTester(input, optionsManager)
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
       tester.poke("reset", 1)
       tester.step()
       tester.poke("reset", 0)

--- a/src/test/scala/treadle/RegOfVecSpec.scala
+++ b/src/test/scala/treadle/RegOfVecSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.StopException
 
@@ -91,15 +92,7 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false
-      )
-    }
-
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.poke("reset", 1)
     tester.step(3)
@@ -138,17 +131,7 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         |    stop(clock, and(and(and(UInt<1>("h1"), done), _T_18), UInt<1>("h1")), 0) @[Reg.scala 61:9]
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = true,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        callResetAtStartUp = true
-      )
-    }
-
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     def show(): Unit = {
       tester.step()

--- a/src/test/scala/treadle/RegisterCycleTest.scala
+++ b/src/test/scala/treadle/RegisterCycleTest.scala
@@ -4,6 +4,7 @@ package treadle
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 //scalastyle:off magic.number
@@ -42,8 +43,7 @@ class RegisterCycleTest extends FreeSpec with Matchers {
       for(i <- 0 to 10) {
         println(s"experiment $i")
         scala.util.Random.setSeed(i.toLong)
-        val tester = TreadleTester(input)
-//        tester.setVerbose(true)
+        val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
         tester.poke("reset", 1)
         tester.step()
@@ -90,7 +90,10 @@ class RegisterCycleTest extends FreeSpec with Matchers {
         val optionsManager = new TreadleOptionsManager
         optionsManager.parser.parse(Array("-tstw", "io_Out,mySubModule_1.io_Out"))
 
-        val tester = TreadleTester(input, optionsManager)
+        val tester = TreadleTester(
+          Seq(FirrtlSourceAnnotation(input), SymbolsToWatchAnnotation(Seq("io_Out", "mySubModule_1.io_Out")))
+        )
+
         tester.poke("io_In", 1)
         tester.step(3)
         tester.expect("io_Out", 1)

--- a/src/test/scala/treadle/RegisterSpec.scala
+++ b/src/test/scala/treadle/RegisterSpec.scala
@@ -1,6 +1,8 @@
 // See LICENSE for license details.
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
+import firrtl.transforms.NoDCEAnnotation
 import org.scalatest.{FlatSpec, Matchers}
 
 // scalastyle:off magic.number
@@ -23,14 +25,7 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        callResetAtStartUp = true,
-        showFirrtlAtLoad = false
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), CallResetAtStartupAnnotation))
 
     tester.poke("reset1", 1)
     tester.step()
@@ -79,13 +74,7 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        callResetAtStartUp = true
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), CallResetAtStartupAnnotation))
 
     tester.poke("reset1", 1)
     tester.poke("reset2", 0)
@@ -155,10 +144,8 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false, writeVCD = false)
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
     tester.poke("reset", 1)
     tester.step()
     tester.poke("reset", 0)
@@ -185,13 +172,7 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        callResetAtStartUp = true,
-        writeVCD = false)
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), CallResetAtStartupAnnotation))
 
     tester.poke("reset1", 1)
     tester.step()
@@ -248,15 +229,7 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        setVerbose = false,
-        callResetAtStartUp = true,
-        showFirrtlAtLoad = false,
-        writeVCD = false
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), CallResetAtStartupAnnotation))
 
     tester.poke("in", 7)
     tester.step()
@@ -313,15 +286,9 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        showFirrtlAtLoad = false,
-        setVerbose = false,
-        callResetAtStartUp = true,
-        writeVCD = false,
-        rollbackBuffers = 15)
-    }
-    val tester = TreadleTester(input, manager)
+    val tester = TreadleTester(
+      Seq(FirrtlSourceAnnotation(input), CallResetAtStartupAnnotation, RollBackBuffersAnnotation(15))
+    )
 
     tester.poke("io_in", 77)
     tester.poke("io_en", 0)
@@ -369,17 +336,7 @@ class RegisterSpec extends FlatSpec with Matchers {
         |    reg1 <= mux(reset, UInt<1>("h1"), reg0) @[AsyncResetRegTest.scala 160:12]
       """.stripMargin
 
-    val manager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        showFirrtlAtLoad = true,
-        setVerbose = false,
-        lowCompileAtLoad = true
-      )
-      firrtlOptions = firrtlOptions.copy(
-        noDCE = true
-      )
-    }
-    val tester = TreadleTester(input, manager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), ShowFirrtlAtLoadAnnotation, NoDCEAnnotation))
 
     tester.expect("io_out_0", 0)
     tester.expect("io_out_1", 0)

--- a/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
+++ b/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.{ClockInfo, StopException}
 
@@ -10,28 +11,22 @@ class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
   "riscv-mini simple core test should run then stop" in {
 
     val stream = getClass.getResourceAsStream("/core-simple.lo.fir")
-    val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
+    val input =
+      scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 0,
-        clockInfo = Seq(ClockInfo("clock", period = 10, initialOffset = 1)),
-        symbolsToWatch = Seq()
+    val tester = TreadleTester(
+      Seq(
+        FirrtlSourceAnnotation(input),
+        ClockInfoAnnotation(
+          Seq(ClockInfo("clock", period = 10, initialOffset = 1))
+        )
       )
-    }
-
-    val tester = TreadleTester(input, optionsManager)
+    )
 
     intercept[StopException] {
       tester.step(400)
     }
     tester.report()
-    tester.engine.writeVCD()
-    tester.engine.lastStopResult should be (Some(0))
+    tester.engine.lastStopResult should be(Some(0))
   }
 }
-

--- a/src/test/scala/treadle/ShiftRegisterSpec.scala
+++ b/src/test/scala/treadle/ShiftRegisterSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.StopException
 
@@ -35,19 +36,8 @@ class ShiftRegisterSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 4,
-        callResetAtStartUp = true,
-        symbolsToWatch = Seq() // Seq("sr", "sr/in")
-      )
-    }
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), RollBackBuffersAnnotation(4)))
 
-    val tester = TreadleTester(input, optionsManager)
 
     intercept[StopException] {
       tester.step(8)

--- a/src/test/scala/treadle/SimpleVendingMachineSpec.scala
+++ b/src/test/scala/treadle/SimpleVendingMachineSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.StopException
 
@@ -150,18 +151,8 @@ class SimpleVendingMachineSpec extends FreeSpec with Matchers{
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 0,
-        symbolsToWatch = Seq("dut.state", "dut.state/in")
-      )
-    }
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
-    val tester = TreadleTester(input, optionsManager)
 
     intercept[StopException] {
       tester.step(80)

--- a/src/test/scala/treadle/SnapshotSpec.scala
+++ b/src/test/scala/treadle/SnapshotSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 
@@ -35,18 +36,8 @@ class SnapshotSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 4,
-        symbolsToWatch = Seq()
-      )
-    }
+    val t = TreadleTester(Seq(FirrtlSourceAnnotation(input), RollBackBuffersAnnotation(4)))
 
-    val t = TreadleTester(input, optionsManager)
     t.poke("in0", 1)
     t.step()
     t.poke("in0", 2)

--- a/src/test/scala/treadle/StackSpec.scala
+++ b/src/test/scala/treadle/StackSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 
@@ -80,18 +81,7 @@ class StackSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        writeVCD = false,
-        vcdShowUnderscored = false,
-        setVerbose = false,
-        showFirrtlAtLoad = false,
-        rollbackBuffers = 0,
-        symbolsToWatch = Seq()
-      )
-    }
-
-    val tester = TreadleTester(input, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.poke("io_en", 1)
     tester.poke("io_push", 1)

--- a/src/test/scala/treadle/StopBehaviorSpec.scala
+++ b/src/test/scala/treadle/StopBehaviorSpec.scala
@@ -3,6 +3,7 @@
 package treadle
 
 import firrtl.CommonOptions
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.StopException
 
@@ -48,13 +49,8 @@ class StopBehaviorSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "Stop should abort engine immediately" in {
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(
-        callResetAtStartUp = true,
-        setVerbose = false
-      )
-    }
-    val tester = TreadleTester(input, optionsManager)
+
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), CallResetAtStartupAnnotation))
 
     tester.poke("reset", 0)
     tester.poke("io_wrData", (0 << 24) + (255 << 16))

--- a/src/test/scala/treadle/VecSpec.scala
+++ b/src/test/scala/treadle/VecSpec.scala
@@ -2,8 +2,8 @@
 
 package treadle
 
-import firrtl.stage.FirrtlSourceAnnotation
-import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
+import firrtl.options.TargetDirAnnotation
+import firrtl.stage.{FirrtlSourceAnnotation, OutputFileAnnotation}
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.StopException
 
@@ -36,7 +36,8 @@ class VecSpec extends FreeSpec with Matchers {
     val options = Seq(
       WriteVcdAnnotation,
       RollBackBuffersAnnotation(20),
-      TopNameAnnotation("vec_spec_1")
+      TargetDirAnnotation("test_run_dir/vec_spec_1"),
+      OutputFileAnnotation("vec_spec_1")
     )
 
     val tester = TreadleTester(FirrtlSourceAnnotation(input) +: options)
@@ -119,7 +120,11 @@ class VecSpec extends FreeSpec with Matchers {
         |
       """.stripMargin
 
-    val options = Seq(WriteVcdAnnotation)
+    val options = Seq(
+      WriteVcdAnnotation,
+      TargetDirAnnotation("test_run_dir/vec_spec_2"),
+      OutputFileAnnotation("vec_spec_2")
+    )
 
     val tester = TreadleTester(FirrtlSourceAnnotation(input) +: options)
 

--- a/src/test/scala/treadle/blackboxes/AsyncResetRegSpec.scala
+++ b/src/test/scala/treadle/blackboxes/AsyncResetRegSpec.scala
@@ -2,7 +2,8 @@
 
 package treadle.blackboxes
 
-import firrtl.stage.FirrtlSourceAnnotation
+import firrtl.options.TargetDirAnnotation
+import firrtl.stage.{FirrtlSourceAnnotation, OutputFileAnnotation}
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.asyncreset.AsyncResetBlackBoxFactory
 import treadle.{BlackBoxFactoriesAnnotation, ShowFirrtlAtLoadAnnotation, TreadleTester, WriteVcdAnnotation}
@@ -154,6 +155,8 @@ class AsyncResetRegSpec extends FreeSpec with Matchers {
 
     val options = Seq(
       WriteVcdAnnotation,
+      TargetDirAnnotation("test_run_dir/async_reset_1"),
+      OutputFileAnnotation("async_reset_1"),
       BlackBoxFactoriesAnnotation(Seq(new AsyncResetBlackBoxFactory))
     )
 
@@ -240,6 +243,8 @@ class AsyncResetRegSpec extends FreeSpec with Matchers {
 
     val options = Seq(
       WriteVcdAnnotation,
+      TargetDirAnnotation("test_run_dir/async_reset_2"),
+      OutputFileAnnotation("async_reset_2"),
       BlackBoxFactoriesAnnotation(Seq(new AsyncResetBlackBoxFactory))
     )
 

--- a/src/test/scala/treadle/chronometry/ClockMadnessSpec.scala
+++ b/src/test/scala/treadle/chronometry/ClockMadnessSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle.chronometry
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.TreadleTester
 
@@ -40,14 +41,8 @@ class ClockMadnessSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "ClockMadnessSpec should pass a basic test" in {
-    val tester = TreadleTester(input)
-    //    tester.poke("reset", 0)
-    //    tester.poke("io_enable", 1)
-    //    for(_ <- 0 until 3) {
-    //      println(s">>>>>>>>>>>>>counter = ${tester.peek("io_count")}")
-    //      tester.step()
-    //    }
 
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
     tester.poke("io_enable", 0)
     for(_ <- 0 until 10) {
       println(s"counter = ${tester.peek("io_count")}")

--- a/src/test/scala/treadle/chronometry/GatedClockSpec.scala
+++ b/src/test/scala/treadle/chronometry/GatedClockSpec.scala
@@ -2,6 +2,7 @@
 
 package treadle.chronometry
 
+import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.TreadleTester
 
@@ -40,15 +41,8 @@ class GatedClockSpec extends FreeSpec with Matchers {
     """.stripMargin
 
   "GatedClockSpec should pass a basic test" in {
-    val tester = TreadleTester(input)
-    // tester.setVerbose()
 
-    //    tester.poke("reset", 0)
-//    tester.poke("io_enable", 1)
-//    for(_ <- 0 until 3) {
-//      println(s">>>>>>>>>>>>>counter = ${tester.peek("io_count")}")
-//      tester.step()
-//    }
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
 
     tester.poke("io_enable", 0)
     for(_ <- 0 until 10) {

--- a/src/test/scala/treadle/chronometry/PrintfOnDerivedClockSpec.scala
+++ b/src/test/scala/treadle/chronometry/PrintfOnDerivedClockSpec.scala
@@ -4,8 +4,8 @@ package treadle.chronometry
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
-import firrtl.stage.FirrtlSourceAnnotation
-import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
+import firrtl.options.TargetDirAnnotation
+import firrtl.stage.{FirrtlSourceAnnotation, OutputFileAnnotation}
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.TreadleTester
 
@@ -41,7 +41,8 @@ class PrintfOnDerivedClockSpec extends FreeSpec with Matchers {
     val output = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(output)) {
       val options = Seq(
-        TopNameAnnotation("printf_on_derived_clock")
+        TargetDirAnnotation("test_run_dir/print_on_derived_clock"),
+        OutputFileAnnotation("printf_on_derived_clock")
       )
 
       val tester = TreadleTester(FirrtlSourceAnnotation(input) +: options)

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -2,13 +2,11 @@
 
 package treadle.executable
 
-import firrtl.CommonOptions
 import firrtl.graph.CyclicException
 import firrtl.stage.FirrtlSourceAnnotation
 import firrtl.transforms.DontCheckCombLoopsAnnotation
-import treadle._
 import org.scalatest.{FreeSpec, Matchers}
-import treadle.chronometry.UTC
+import treadle._
 
 //scalastyle:off magic.number
 class SymbolTableSpec extends FreeSpec with Matchers {
@@ -39,7 +37,6 @@ class SymbolTableSpec extends FreeSpec with Matchers {
     """
         .stripMargin
 
-    val wallTime = new UTC()
     val simulator = TreadleTester(Seq(FirrtlSourceAnnotation(simpleFirrtl)))
 
     val symbolTable = simulator.engine.symbolTable
@@ -80,8 +77,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new TreadleOptionsManager
-    val tester = TreadleTester(simpleFirrtl, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(simpleFirrtl)))
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -126,8 +122,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new TreadleOptionsManager
-    val tester = TreadleTester(simpleFirrtl, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(simpleFirrtl)))
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -181,11 +176,7 @@ class SymbolTableSpec extends FreeSpec with Matchers {
          """
         .stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
-    }
-    val tester = TreadleTester(simpleFirrtl, optionsManager)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(simpleFirrtl)))
     val simulator = tester.engine
 
     val symbolTable = simulator.symbolTable
@@ -260,14 +251,8 @@ class SymbolTableSpec extends FreeSpec with Matchers {
        """
               .stripMargin
 
-    val optionsManager = new TreadleOptionsManager {
-      treadleOptions = treadleOptions.copy(setVerbose = false)
-      firrtlOptions = firrtlOptions.copy(annotations = firrtlOptions.annotations :+ DontCheckCombLoopsAnnotation)
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
-    }
-
     try {
-      TreadleTester(simpleFirrtl, optionsManager)
+      TreadleTester(Seq(FirrtlSourceAnnotation(simpleFirrtl), DontCheckCombLoopsAnnotation))
     }
     catch {
       case c: CyclicException =>

--- a/src/test/scala/treadle/primops/AndOrXor.scala
+++ b/src/test/scala/treadle/primops/AndOrXor.scala
@@ -2,6 +2,7 @@
 
 package treadle.primops
 
+import firrtl.stage.FirrtlSourceAnnotation
 import treadle.executable.{AndInts, OrInts, XorInts}
 import treadle.{BitTwiddlingUtils, TreadleTester, extremaOfSIntOfWidth, extremaOfUIntOfWidth}
 import org.scalatest.{FreeSpec, Matchers}
@@ -156,7 +157,8 @@ class AndOrXor extends FreeSpec with Matchers {
         |
       """.stripMargin
     val bitWidth = 4
-    val tester = TreadleTester(input)
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
     val (lo, hi) = extremaOfSIntOfWidth(bitWidth)
     for {
       a <- lo to hi

--- a/src/test/scala/treadle/primops/AndrOrrXorr.scala
+++ b/src/test/scala/treadle/primops/AndrOrrXorr.scala
@@ -2,6 +2,7 @@
 
 package treadle.primops
 
+import firrtl.stage.FirrtlSourceAnnotation
 import treadle.executable._
 import treadle._
 import org.scalatest.{FreeSpec, Matchers}
@@ -140,14 +141,6 @@ class AndrOrrXorr extends FreeSpec with Matchers {
           |    io_out_xorr <= _T_5 @[XorReducer.scala 15:11]
         """.stripMargin
 
-      val manager = new TreadleOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          showFirrtlAtLoad = false,
-          setVerbose = false,
-          rollbackBuffers = 0
-        )
-      }
-
       def scalaXorReduce(x: BigInt, width: Int): Int = {
         if(x.bitCount % 2 == 0) 0 else 1
       }
@@ -160,7 +153,8 @@ class AndrOrrXorr extends FreeSpec with Matchers {
         if((0 until width).exists(i => x.testBit(i))) 1 else 0
       }
 
-      val t = TreadleTester(input, manager)
+      val t = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
       for {
         i0 <- 0 to 1
         i1 <- 0 to 1

--- a/src/test/scala/treadle/primops/CatBitsHeadTail.scala
+++ b/src/test/scala/treadle/primops/CatBitsHeadTail.scala
@@ -215,15 +215,14 @@ class CatBitsHeadTail extends FreeSpec with Matchers {
       "tail ops should drop leading bits from expression" in {
         TailInts(() => -22, toDrop = 1, originalWidth = 16)() should be(32746)
 
-        TailInts(f1, toDrop = 1, originalWidth = 2)() should be(1)
-        TailInts(f2, toDrop = 1, originalWidth = 3)() should be(2)
-        TailInts(f3, toDrop = 1, originalWidth = 3)() should be(3)
-        TailInts(f3, toDrop = 1, originalWidth = 2)() should be(1)
-        TailInts(fMinus3, toDrop = 1, originalWidth = 4)() should be(5)
-        TailInts(fMinus4, toDrop = 1, originalWidth = 4)() should be(4)
+        TailInts(() => f1(), toDrop = 1, originalWidth = 2)() should be(1)
+        TailInts(() => f2(), toDrop = 1, originalWidth = 3)() should be(2)
+        TailInts(() => f3(), toDrop = 1, originalWidth = 3)() should be(3)
+        TailInts(() => f3(), toDrop = 1, originalWidth = 2)() should be(1)
+        TailInts(() => fMinus3(), toDrop = 1, originalWidth = 4)() should be(5)
+        TailInts(() => fMinus4(), toDrop = 1, originalWidth = 4)() should be(4)
 
-        val tailOps = TailInts(val1, toDrop = 9, originalWidth = 17)
-        // println(f"TailInts(${val1()}%x, toDrop = 8) -> ${tailOps()}%x")
+        val tailOps = TailInts(() => val1(), toDrop = 9, originalWidth = 17)
         tailOps() should be(Integer.parseInt("cd", 16))
       }
     }

--- a/src/test/scala/treadle/vcd/VCDSpec.scala
+++ b/src/test/scala/treadle/vcd/VCDSpec.scala
@@ -4,11 +4,9 @@ package treadle.vcd
 
 import java.io.File
 
-import firrtl.CommonOptions
-import firrtl.options.{StageOptions, TargetDirAnnotation}
 import firrtl.options.Viewer.view
-import firrtl.stage.FirrtlSourceAnnotation
-import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
+import firrtl.options.{StageOptions, TargetDirAnnotation}
+import firrtl.stage.{FirrtlSourceAnnotation, OutputFileAnnotation}
 import firrtl.util.BackendCompilationUtilities
 import org.scalatest.{FlatSpec, Matchers}
 import treadle._
@@ -152,7 +150,9 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
       """.stripMargin
 
     val options = Seq(
-      WriteVcdAnnotation
+      WriteVcdAnnotation,
+      TargetDirAnnotation("test_run_dir/vcd_reader_1"),
+      OutputFileAnnotation("vcd_reader_1")
     )
 
     val engine = TreadleTester(FirrtlSourceAnnotation(input) +: options)
@@ -183,7 +183,9 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
     val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
 
     val options = Seq(
-      WriteVcdAnnotation
+      WriteVcdAnnotation,
+      TargetDirAnnotation("test_run_dir/vcd_reader_2"),
+      OutputFileAnnotation("vcd_reader_2")
     )
 
     val engine = TreadleTester(FirrtlSourceAnnotation(input) +: options)
@@ -235,7 +237,7 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
       Some(WriteVcdAnnotation),
       if(hasTempWires) { Some(VcdShowUnderScoredAnnotation) } else { None },
       Some(TargetDirAnnotation("test_run_dir/vcd_register_delay/")),
-      Some(TopNameAnnotation("pwminCount"))
+      Some(OutputFileAnnotation("pwminCount"))
     ).flatten
 
     val engine = TreadleTester(FirrtlSourceAnnotation(input) +: options)
@@ -294,7 +296,7 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
       FirrtlSourceAnnotation(input),
       WriteVcdAnnotation,
       TargetDirAnnotation(targetDir),
-      TopNameAnnotation("VcdAdder"),
+      OutputFileAnnotation("VcdAdder"),
       VcdReplayVcdFile(s"$targetDir/VcdAdder.vcd")
     )
 


### PR DESCRIPTION
On top of the abstractions suggested in #109 , this decouples the `RollbackBufferManager` from the concrete `DataStore` used. This is the first commit in this series where I am somewhat skeptical about how it might affect performance.

@chick, is there a reliable way to test `treadle` for performance regressions?