### PR TITLE
Attempt to fix ordering of stop statements

### DIFF
--- a/src/main/scala/treadle/executable/StopOp.scala
+++ b/src/main/scala/treadle/executable/StopOp.scala
@@ -17,10 +17,17 @@ case class StopOp(
   def run: FuncUnit = {
     val conditionValue = condition.apply() > 0
     if (conditionValue && clockTransition.isPosEdge) {
-      if (isVerbose) {
-        println(s"clock ${symbol.name} has fired")
+      if(dataStore(hasStopped) > 0) {
+        if (isVerbose) {
+          println(s"previous stop has fired with result ${dataStore(hasStopped)}")
+        }
       }
-      dataStore(hasStopped) = returnValue + 1
+      else {
+        if (isVerbose) {
+          println(s"stop ${symbol.name} has fired")
+        }
+        dataStore(hasStopped) = returnValue + 1
+      }
     }
 
     () => Unit

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -190,6 +190,9 @@ object SymbolTable extends LazyLogging {
 
     val registerToClock   = new mutable.HashMap[Symbol, Symbol]
     val stopToStopInfo    = new mutable.HashMap[Stop, StopInfo]
+
+    val lastStopStymbol   = new mutable.HashMap[Module, Symbol]
+
     val printToPrintInfo  = new mutable.HashMap[Print, PrintInfo]
 
     val moduleMemoryToMemorySymbol = new mutable.HashMap[String, mutable.HashSet[Symbol]] {
@@ -392,6 +395,11 @@ object SymbolTable extends LazyLogging {
 
               addDependency(stopSymbol, expressionToReferences(clockExpression))
               addDependency(stopSymbol, expressionToReferences(enableExpression))
+              lastStopStymbol.get(module) match {
+                case Some(lastSymbol) => addDependency(stopSymbol, Set(lastSymbol))
+                case _ =>
+              }
+              lastStopStymbol(module) = stopSymbol
 
               if(! nameToSymbol.contains(StopOp.stopHappenedName)) {
                 addSymbol(

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -385,7 +385,7 @@ object SymbolTable extends LazyLogging {
           moduleMemoryToMemorySymbol(moduleMemory) += memorySymbols.head
 
 
-        case stop @ Stop(info, args, clockExpression, enableExpression)   =>
+        case stop @ Stop(info, _, clockExpression, enableExpression)   =>
           getClockSymbol(clockExpression) match {
             case Some(_) =>
               val stopSymbolName = makeStopName()


### PR DESCRIPTION
Make a local dependency between successive stops on
a per module basis.
Stop behavior now checks to see if previous stop has happened.
Add test to show that this worked