### PR TITLE
Now that stop ordering is fixed two tests were found that

### DIFF
--- a/src/test/scala/treadle/RegOfVecSpec.scala
+++ b/src/test/scala/treadle/RegOfVecSpec.scala
@@ -94,7 +94,7 @@ class RegOfVecSpec extends FreeSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         writeVCD = false,
-        setVerbose = false,
+        setVerbose = true,
         showFirrtlAtLoad = false
       )
     }
@@ -134,6 +134,7 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         |    sr <= mux(reset, UInt<1>("h1"), _GEN_0)
         |    printf(clock, UInt<1>("h1"), "XXXXXXXXXXXXXXXX     clock %d, done %d, sr %d, reset %d\n", asUInt(clock), done, sr, asUInt(reset))
         |    printf(clock, and(and(and(UInt<1>("h1"), done), _T_15), UInt<1>("h1")), "Assertion failed\n    at Reg.scala:60 assert(sr === 1.U)\n") @[Reg.scala 60:11]
+        |    printf(clock, UInt<1>("h1"), "XXXXXXXXXX _T_15 %d and _T_18 %d\n", _T_15, _T_18);
         |    stop(clock, and(and(and(UInt<1>("h1"), done), _T_15), UInt<1>("h1")), 1) @[Reg.scala 60:11]
         |    stop(clock, and(and(and(UInt<1>("h1"), done), _T_18), UInt<1>("h1")), 0) @[Reg.scala 61:9]
       """.stripMargin
@@ -163,6 +164,7 @@ class RegOfVecSpec extends FreeSpec with Matchers {
       show()
       show()
     }
-    tester.engine.lastStopResult should be (Some(0))
+    // The first stop to fire, based on the conditions and the order within the module
+    tester.engine.lastStopResult should be (Some(1))
   }
 }

--- a/src/test/scala/treadle/ShiftRegisterSpec.scala
+++ b/src/test/scala/treadle/ShiftRegisterSpec.scala
@@ -52,7 +52,7 @@ class ShiftRegisterSpec extends FreeSpec with Matchers {
     intercept[StopException] {
       tester.step(8)
     }
-    tester.engine.lastStopResult should be (Some(0))
+    tester.engine.lastStopResult should be (Some(1))
     tester.report()
   }
 }


### PR DESCRIPTION
were based on the incorrect stop ordering.
These have both been fixed so that stop result returned
is recognized to be the first stop statement in the module
that fired.