### PR TITLE
Fix REPL not running because of duplicated annotation flag

### DIFF
--- a/src/main/scala/treadle/repl/ReplOptions.scala
+++ b/src/main/scala/treadle/repl/ReplOptions.scala
@@ -12,20 +12,6 @@ sealed trait ReplOption extends Unserializable { this: Annotation => }
 
 case class OverrideOutputStream(outputStream: OutputStream) extends NoTargetAnnotation
 
-/**
-  *  The source file to load firrtl from for repl
-  */
-case object FirrtlFileName extends HasShellOptions {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[String](
-      longOption = "tr-firrtl-source-file",
-      shortOption = Some("tfsf"),
-      toAnnotationSeq = (fileName: String) => Seq(FirrtlFileAnnotation(fileName)),
-      helpText = "file containing the Firrtl source to be used in Repl"
-    )
-  )
-}
-
 case class DefaultFileNameWithOutSuffix(fileName: String)
 
 /**

--- a/src/main/scala/treadle/repl/TreadleReplCli.scala
+++ b/src/main/scala/treadle/repl/TreadleReplCli.scala
@@ -9,7 +9,6 @@ trait TreadleReplCli { this: Shell =>
   parser.note("TreadleRepl specific options")
 
   Seq(
-    FirrtlFileName,
     TreadleScriptFile,
     TreadleReplUseVcd,
     TreadleVcdScriptFileOverride,

--- a/src/main/scala/treadle/stage/TreadleStage.scala
+++ b/src/main/scala/treadle/stage/TreadleStage.scala
@@ -29,7 +29,7 @@ object TreadleCompatibilityPhase extends Phase {
   def checkFormTransform(circuitForm: CircuitForm, annotations: AnnotationSeq): AnnotationSeq = {
     val phases = circuitForm match {
       case ChirrtlForm => chirrtlPhases
-      case LowForm => lowFIRRTLPhases
+      case _ => lowFIRRTLPhases
     }
     phases.foldLeft(annotations)( (a, f) => f.transform(a) )
   }


### PR DESCRIPTION
Repl was not running because of two things
- duplicated flag.
- input that somehow not flagged as Low or Chirrtl causes unhandled match