### PR TITLE
Repl needs advance time

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -110,6 +110,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
   def advanceTime(interval: Long): Unit = {
     assert(interval >= 0L, "TreadleTester#advanceTime called with negative value")
     wallTime.setTime(wallTime.currentTime + interval)
+    engine.evaluateCircuit()
   }
 
   /*

--- a/src/main/scala/treadle/executable/ClockInfo.scala
+++ b/src/main/scala/treadle/executable/ClockInfo.scala
@@ -29,6 +29,11 @@ case class ClockInfo(
   if(initialOffset <= 0) {
     throw TreadleException(s"initialOffset in ClockInfo for $name must be positive. Found value $initialOffset")
   }
+
+  def prettyString: String = {
+    def detail = s"(up: $upPeriod, down: $downPeriod)"
+    f"$name%-40.40s period $period%5d,  $detail%15s, first up at $initialOffset"
+  }
 }
 
 /**

--- a/src/main/scala/treadle/repl/ReplOptions.scala
+++ b/src/main/scala/treadle/repl/ReplOptions.scala
@@ -12,20 +12,6 @@ sealed trait ReplOption extends Unserializable { this: Annotation => }
 
 case class OverrideOutputStream(outputStream: OutputStream) extends NoTargetAnnotation
 
-/**
-  *  The source file to load firrtl from for repl
-  */
-case object FirrtlFileName extends HasShellOptions {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[String](
-      longOption = "tr-firrtl-source-file",
-      shortOption = Some("tfsf"),
-      toAnnotationSeq = (fileName: String) => Seq(FirrtlFileAnnotation(fileName)),
-      helpText = "file containing the Firrtl source to be used in Repl"
-    )
-  )
-}
-
 case class DefaultFileNameWithOutSuffix(fileName: String)
 
 /**

--- a/src/main/scala/treadle/repl/TreadleReplCli.scala
+++ b/src/main/scala/treadle/repl/TreadleReplCli.scala
@@ -9,7 +9,6 @@ trait TreadleReplCli { this: Shell =>
   parser.note("TreadleRepl specific options")
 
   Seq(
-    FirrtlFileName,
     TreadleScriptFile,
     TreadleReplUseVcd,
     TreadleVcdScriptFileOverride,

--- a/src/main/scala/treadle/stage/TreadleStage.scala
+++ b/src/main/scala/treadle/stage/TreadleStage.scala
@@ -29,7 +29,7 @@ object TreadleCompatibilityPhase extends Phase {
   def checkFormTransform(circuitForm: CircuitForm, annotations: AnnotationSeq): AnnotationSeq = {
     val phases = circuitForm match {
       case ChirrtlForm => chirrtlPhases
-      case LowForm => lowFIRRTLPhases
+      case _ => lowFIRRTLPhases
     }
     phases.foldLeft(annotations)( (a, f) => f.transform(a) )
   }

--- a/src/test/scala/treadle/repl/GcdInReplSpec.scala
+++ b/src/test/scala/treadle/repl/GcdInReplSpec.scala
@@ -24,7 +24,7 @@ class GcdInReplSpec extends FreeSpec with Matchers {
     printFile.println("poke io_e 0")
     printFile.println("waitfor io_v 1")
     printFile.println("peek io_z")
-        printFile.println("quit")
+    printFile.println("quit")
     printFile.close()
 
     val output = new ByteArrayOutputStream()
@@ -49,5 +49,59 @@ class GcdInReplSpec extends FreeSpec with Matchers {
     textOut.contains("io_v == value 1 in 3 cycle") should be (true)
     textOut.contains("peek io_z 4") should be (true)
 
+  }
+
+  "run gcd to with manual clock manipulation gcd(8,12) => 4" in {
+    val targetDir = "test_run_dir/repl/gcd-test-man-clock"
+    val replInputFile = targetDir + File.separator + "gcd.in"
+
+    val stream = getClass.getResourceAsStream("/GCD.fir")
+    val input = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
+
+    FileUtils.makeDirectory(targetDir)
+    val printFile = new PrintStream(new File(replInputFile))
+
+    def manualStep(): Unit = {
+      printFile.println("walltime 10 ; poke clk 1 ; walltime 10; poke clk 0")
+    }
+
+    printFile.println("show clocks")
+    printFile.println("poke io_a 8 ; poke io_b 12; poke io_e 1")
+    manualStep()
+    printFile.println("poke io_e 0")
+
+    manualStep()
+    manualStep()
+    manualStep()
+    manualStep()
+    manualStep()
+
+    printFile.println("peek io_v ; peek io_z")
+    printFile.println("quit")
+    printFile.close()
+
+    val output = new ByteArrayOutputStream()
+
+    val annotations = Seq(
+      FirrtlSourceAnnotation(input),
+      OverrideOutputStream(output),
+      TargetDirAnnotation(targetDir),
+      TreadleScriptFile(replInputFile),
+      TreadleReplRunScriptAtStartup
+    )
+
+    Console.withOut(new PrintStream(output)) {
+      val repl = TreadleRepl(annotations)
+      repl.run()
+    }
+
+    val textOut = output.toString()
+
+    println(textOut)
+
+    textOut.contains("peek io_v 1") should be (true)
+    textOut.contains("peek io_z 4") should be (true)
+    textOut.contains("incremented by 10") should be (true)
+    textOut.contains("period    10,  (up: 5, down: 5)") should be (true)
   }
 }


### PR DESCRIPTION
Treadle can use step or clocks and the wall time can be manipulated
manually. The Repl did not get appropriate commands to utilize
this new capability.
This PR adds it. It includes
- new Repl Command walltime which
  - with no args shows current wall time
  - with a positive increment will advance the wall time by that ammount
  - re-evaluates circuit when advance time occurs
- adds new subcommand clocks to show command
  - shows a pretty list of all top level inputs of type clock
  - uses a new prettyPrint method of ClockInfo
- Add a test that shows a manually clocked repl session