### PR TITLE
ExpressionCompiler: make manual clocking work with asClock(clk)

### DIFF
--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -192,6 +192,7 @@ class ExpressionCompiler(
           } yield {
             topClock
           }
+        case DoPrim(AsClock, Seq(arg), _, _) => getDrivingClock(arg)
         case _ =>
           None
       }


### PR DESCRIPTION
The yosys backend wraps all clock signals in `asClock`.
Not sure why the firrtl type checker allows register clock
signals of type UInt<1> without casting.