### PR TITLE
Fix incorrect -doc-source-url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,7 +130,7 @@ scalacOptions in Compile in doc ++= Seq(
   "-diagrams",
   "-diagrams-max-classes", "25",
   "-doc-version", version.value,
-  "-doc-source-url", "https://github.com/freechipsproject/chisel-testers/tree/master/€{FILE_PATH}.scala",
+  "-doc-source-url", "https://github.com/freechipsproject/treadle/tree/master/€{FILE_PATH}.scala",
   "-sourcepath", baseDirectory.value.getAbsolutePath,
   "-unchecked"
 ) ++ scalacOptionsVersion(scalaVersion.value)


### PR DESCRIPTION
This is currently pointing the `-doc-source-url` at testers and it should be treadle. This will fix the source urls not working on the SNAPSHOT documentation of the website pointing at the wrong GitHub urls (once a new SNAPSHOT is released).