### PR TITLE
Add new `watch` command to repl

### DIFF
--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -11,7 +11,7 @@ import firrtl.options.{OptionsException, StageOptions, StageUtils, TargetDirAnno
 import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlSourceAnnotation, OutputFileAnnotation}
 import org.json4s.native.JsonMethods._
 import treadle.chronometry.UTC
-import treadle.executable.{ExecutionEngine, Symbol, SymbolTable, TreadleException, WaveformValues}
+import treadle.executable.{ExecutionEngine, RenderComputations, Symbol, SymbolTable, TreadleException, WaveformValues}
 import treadle.repl._
 import treadle.stage.TreadleTesterPhase
 import treadle.vcd.VCD
@@ -519,6 +519,71 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
                   error(s"exception ${a.getMessage}")
               }
             case _ =>
+          }
+        }
+      },
+      new Command("watch") {
+        private def peekableThings: Seq[String] = engine.validNames.toSeq
+        def usage: (String, String) = ("watch [+|-] regex [regex ...]", "watch (+) or unwatch (-) signals")
+
+        override def completer: Option[ArgumentCompleter] = {
+          if(currentTreadleTesterOpt.isEmpty) {
+            None
+          }
+          else {
+            Some(new ArgumentCompleter(
+              new StringsCompleter({"watch"}),
+              new StringsCompleter(jlist(peekableThings))
+            ))
+          }
+        }
+
+        //scalastyle:off cyclomatic.complexity
+        def run(args: Array[String]): Unit = {
+          var isAdding = true
+
+          engine.dataStore.plugins.get("show-computation") match {
+            case Some(plugin: RenderComputations) =>
+              args.foreach {
+                case "-" => isAdding = false
+                case "+" => isAdding = true
+                case symbolPattern =>
+                  try {
+                    val portRegex = symbolPattern.r
+                    peekableThings.foreach { signalName =>
+                      portRegex.findFirstIn(signalName) match {
+                        case Some(_) =>
+                          try {
+                            val value = engine.getValue(signalName)
+                            val symbol = engine.symbolTable(signalName)
+                            if (isAdding) {
+                              plugin.symbolsToWatch += symbol
+                              console.println(s"add watch for ${symbol.render} ${formatOutput(value)}")
+                            } else {
+                              plugin.symbolsToWatch -= symbol
+                              console.println(s"removing watch for ${symbol.render} ${formatOutput(value)}")
+                            }
+                          }
+                          catch {
+                            case _: Exception => false
+                          }
+                        case _ =>
+                          false
+                      }
+                    }
+                  }
+                  catch {
+                    case e: Exception =>
+                      error(s"exception ${e.getMessage} $e")
+                    case a: AssertionError =>
+                      error(s"exception ${a.getMessage}")
+                  }
+              }
+              plugin.setEnabled(plugin.symbolsToWatch.nonEmpty)
+              engine.setLeanMode()
+
+            case None =>
+              console.println(s"Can't find watch plugin-in")
           }
         }
       },

--- a/src/main/scala/treadle/executable/DataStorePlugIn.scala
+++ b/src/main/scala/treadle/executable/DataStorePlugIn.scala
@@ -4,6 +4,8 @@ package treadle.executable
 
 import treadle.vcd.VCD
 
+import scala.collection.mutable
+
 abstract class DataStorePlugin {
   def executionEngine: ExecutionEngine
   def dataStore: DataStore
@@ -65,9 +67,10 @@ class RenderComputations(
 ) extends DataStorePlugin {
 
   val dataStore: DataStore = executionEngine.dataStore
-  val symbolsToWatch: Set[Symbol] = symbolNamesToWatch.flatMap { name =>
+  val symbolsToWatch: mutable.HashSet[Symbol] = new mutable.HashSet
+  symbolsToWatch ++= symbolNamesToWatch.flatMap { name =>
     executionEngine.symbolTable.get(name)
-  }.toSet
+  }
 
   def run(symbol: Symbol, offset: Int = -1): Unit = {
     if(symbolsToWatch.contains(symbol)) {


### PR DESCRIPTION
Allows adding and removing symbols to watch during circuit eval
Usage
Add symbols with
watch sym1 [sym2 [...]]
Remove them with
watch - sym1 [sym2 [...]]
More generally + and - can be placed anywhere in the
symbol arguments to toggle between adding and deleting
Make symbols to watch in RenderComputations plugin updatable
This will let Repl change it