### PR TITLE
Ansi escape sequences are a problem when using treadle repl

### DIFF
--- a/treadle.sh
+++ b/treadle.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-sbt -mem 4000 "runMain treadle.TreadleRepl $*"
+sbt -no-colors -mem 4000 "runMain treadle.TreadleRepl $*"


### PR DESCRIPTION
Add -no-colors to treadle.sh start script