### PR TITLE
Avoid double creation of TreadleTester when launching REPL

### DIFF
--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -1459,8 +1459,10 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
     try {
       loadSource()
 
-      if (replConfig.firrtlSourceName.nonEmpty) {
-        loadFile(replConfig.firrtlSourceName)
+      if(! annotationSeq.exists(_.isInstanceOf[TreadleTesterAnnotation])) {
+        if (replConfig.firrtlSourceName.nonEmpty) {
+          loadFile(replConfig.firrtlSourceName)
+        }
       }
       if (replConfig.scriptName.nonEmpty) {
         loadScript(replConfig.scriptName)


### PR DESCRIPTION
Minor fix of problem that is typically only a problem for large files