### PR TITLE
Make it easier to use treadle repl from command line

### DIFF
--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -1529,6 +1529,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
       console.flush()
       history.flush()
       console.shutdown()
+      TerminalFactory.get.restore()
     }
     catch {
       case e: Exception =>

--- a/utils/bin/treadle
+++ b/utils/bin/treadle
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This may be a brittle way to find $(root_dir)/utils/bin, is there a better way?
+path=`dirname "$0"`
+cmd="java -cp ${path}/treadle.jar treadle.TreadleRepl ${@:1}"
+eval $cmd


### PR DESCRIPTION
Add treadle script that calls repl's assembly jar
Figured out how to get terminal restored at end of repl session