### PR TITLE
PrimOp changed in Intervals upstreaming

### DIFF
--- a/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
+++ b/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
@@ -66,7 +66,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    output io : {flip in : Fixed<6><<2>>, out : Fixed}
         |
         |    io is invalid
-        |    node T_2 = bpset(io.in, 0)
+        |    node T_2 = setp(io.in, 0)
         |    io.out <= T_2
       """.stripMargin
 


### PR DESCRIPTION
Problem is that treadle keeps raw firrtl around to run tests on.
- The internal api for set precision is now `setp` for both fixed point an interval
- `bpset` is now `setp`