### PR TITLE
replace getLoweringTransforms to firrtl.stage.phases.Compiler

### DIFF
--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -1554,7 +1554,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
 object TreadleRepl {
   def apply(annotationSeq: AnnotationSeq): TreadleRepl = {
     val newAnnos = TreadleTesterPhase.transform(annotationSeq)
-    new TreadleRepl(newAnnos)
+    new TreadleRepl(annotationSeq ++ newAnnos)
   }
 
   def execute(optionsManager: TreadleOptionsManager with HasReplConfig): Unit = {

--- a/src/main/scala/treadle/stage/TreadleStage.scala
+++ b/src/main/scala/treadle/stage/TreadleStage.scala
@@ -43,6 +43,7 @@ object TreadleTesterPhase extends Phase {
   private val phases: Seq[Phase] = Seq(
     GetFirrtlAst,
     SetImplicitOutputInfo,
+    new firrtl.stage.phases.Compiler,
     PrepareAst,
     CreateTester
   )

--- a/src/main/scala/treadle/stage/phases/GetFirrtlAst.scala
+++ b/src/main/scala/treadle/stage/phases/GetFirrtlAst.scala
@@ -58,6 +58,7 @@ object GetFirrtlAst extends Phase {
         }
       }
     }
-    newAnnotations
+    /** add default [[firrtl.LowFirrtlCompiler]] for [[firrtl.stage.phases.Compiler]]*/
+    newAnnotations :+ firrtl.stage.CompilerAnnotation(new firrtl.LowFirrtlCompiler)
   }
 }

--- a/src/main/scala/treadle/stage/phases/PrepareAst.scala
+++ b/src/main/scala/treadle/stage/phases/PrepareAst.scala
@@ -73,7 +73,6 @@ object PrepareAstFromLowFIRRTL extends TreadlePhase {
   */
 object PrepareAst extends TreadlePhase {
   val transforms: Seq[Transform] = {
-    getLoweringTransforms(ChirrtlForm, LowForm) ++
       Seq(
         new TreadleLowFirrtlOptimization,
         new BlackBoxSourceHelper,

--- a/src/test/scala/treadle/BoreSpec.scala
+++ b/src/test/scala/treadle/BoreSpec.scala
@@ -1,0 +1,59 @@
+// See LICENSE for license details.
+
+package treadle
+
+import firrtl._
+import firrtl.annotations._
+import firrtl.transforms._
+import firrtl.stage._
+import firrtl.passes.wiring._
+
+import org.scalatest.{FreeSpec, Matchers}
+
+class BoreSpec extends FreeSpec with Matchers {
+  "WiringTransform should be honor" in {
+    val input =
+      """
+        |circuit BoreTestTop :
+        |  module BoreTestConstant :
+        |    input clock : Clock
+        |    input reset : Reset
+        |
+        |    wire x : UInt<6>
+        |    x <= UInt<6>("h02a")
+        |
+        |  module BoreTestExpect :
+        |    input clock : Clock
+        |    input reset : Reset
+        |    output y : UInt<6>
+        |
+        |    y <= UInt<1>("h00")
+        |
+        |  module BoreTestTop :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output y : UInt<6>
+        |
+        |    inst constant of BoreTestConstant @[BoreTest.scala 26:26]
+        |    constant.clock <= clock
+        |    constant.reset <= reset
+        |    inst expect of BoreTestExpect @[BoreTest.scala 27:24]
+        |    expect.clock <= clock
+        |    expect.reset <= reset
+        |    y <= expect.y @[BoreTest.scala 28:7]
+        |""".stripMargin
+    val anno = Seq(
+      FirrtlSourceAnnotation(input),
+      SourceAnnotation(ComponentName("x",ModuleName("BoreTestConstant",CircuitName("BoreTestTop"))),"x"),
+      DontTouchAnnotation(ReferenceTarget("BoreTestTop","BoreTestConstant",List(),"x",List())),
+      NoDedupAnnotation(ModuleName("BoreTestConstant",CircuitName("BoreTestTop"))),
+      SinkAnnotation(ComponentName("y",ModuleName("BoreTestExpect",CircuitName("BoreTestTop"))),"x"),
+      NoDedupAnnotation(ModuleName("BoreTestExpect",CircuitName("BoreTestTop"))),
+      RunFirrtlTransformAnnotation(new firrtl.passes.wiring.WiringTransform)
+    )
+
+    val tester = TreadleTester(anno)
+    tester.expect("y", 42)
+    tester.report()
+  }
+}


### PR DESCRIPTION
Emmm, I still don't know why `getLoweringTransforms` doesn't hornor `Annotations`, thus I directly use `firrtl.stage.phases.Compiler` to replace it to fix issue in https://github.com/sequencer/chisel-testers2/tree/honor_annotation,
currently test stack in 
```
[info] ChronometrySpec:
[info] - UTC can schedule a single task
[info] - A clock requires two recurring tasks, one for rising one for falling
[info] - API supports run until task name
[info] - UTC can schedule events for two clocks, 1 to 3 ratio
[info] - How slow is one clock
[info] - How slow are three clocks
| => treadle.repl.ReplShowsHelpFromScriptSpec
```
I'll inspect this later.