### PR TITLE
Testers2 boring fix

### DIFF
--- a/src/main/scala/treadle/TreadleOptions.scala
+++ b/src/main/scala/treadle/TreadleOptions.scala
@@ -2,7 +2,7 @@
 
 package treadle
 
-import firrtl.CircuitState
+import firrtl.{ChirrtlForm, CircuitForm, CircuitState, HighForm, LowForm, UnknownForm}
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
 import firrtl.ir.Circuit
 import firrtl.options.{HasShellOptions, RegisteredLibrary, ShellOption, Unserializable}
@@ -217,8 +217,36 @@ case class TreadleCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation
   */
 case class TreadleCircuitStateAnnotation(state: CircuitState) extends NoTargetAnnotation
 
+/** Provides an input form hint to treadle to know how to best handle the input it receives
+  *
+  * @param form the input form
+  */
+case class TreadleFirrtlFormHint(form: CircuitForm) extends NoTargetAnnotation
+
+object TreadleFirrtlFormHint extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "tr-firrtl-input-form",
+      toAnnotationSeq = (firrtl: String) => {
+        val form = firrtl match {
+          case "low" => LowForm
+          case "high" => HighForm
+          case "chirrtl" => ChirrtlForm
+          case "unknown" => UnknownForm
+          case _ =>
+            throw TreadleException(
+              s"--tr-firrtl-input-form $firrtl is invalid, should be one of high,low,chirrtl,unknown")
+        }
+        Seq(TreadleFirrtlFormHint(form))
+      },
+      helpText = "provides firrtl form hint to treadle, should be one of high,low,chirrtl,unknown"
+    )
+  )
+}
+
 /**
   * Used to pass a tester on to a test harness
+  *
   * @param tester The [[TreadleTester]] to be passed on
   */
 case class TreadleTesterAnnotation(tester: TreadleTester) extends NoTargetAnnotation with TreadleOption

--- a/src/test/scala/treadle/BoreSpec.scala
+++ b/src/test/scala/treadle/BoreSpec.scala
@@ -1,0 +1,61 @@
+// See LICENSE for license details.
+
+package treadle
+
+import firrtl._
+import firrtl.annotations._
+import firrtl.transforms._
+import firrtl.stage._
+import firrtl.passes.wiring._
+
+import org.scalatest.{FreeSpec, Matchers}
+
+class BoreSpec extends FreeSpec with Matchers {
+  "WiringTransform should be honor" in {
+    val input =
+      """
+        |circuit BoreTestTop :
+        |  module BoreTestConstant :
+        |    input clock : Clock
+        |    input reset : Reset
+        |
+        |    wire x : UInt<6>
+        |    x <= UInt<6>("h02a")
+        |
+        |  module BoreTestExpect :
+        |    input clock : Clock
+        |    input reset : Reset
+        |    output y : UInt<6>
+        |
+        |    y <= UInt<1>("h00")
+        |
+        |  module BoreTestTop :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output y : UInt<6>
+        |
+        |    inst constant of BoreTestConstant @[BoreTest.scala 26:26]
+        |    constant.clock <= clock
+        |    constant.reset <= reset
+        |    inst expect of BoreTestExpect @[BoreTest.scala 27:24]
+        |    expect.clock <= clock
+        |    expect.reset <= reset
+        |    y <= expect.y @[BoreTest.scala 28:7]
+        |""".stripMargin
+
+    var annos: AnnotationSeq = Seq(
+      FirrtlSourceAnnotation(input),
+      SourceAnnotation(ComponentName("x",ModuleName("BoreTestConstant",CircuitName("BoreTestTop"))),"x"),
+      DontTouchAnnotation(ReferenceTarget("BoreTestTop","BoreTestConstant",List(),"x",List())),
+      NoDedupAnnotation(ModuleName("BoreTestConstant",CircuitName("BoreTestTop"))),
+      SinkAnnotation(ComponentName("y",ModuleName("BoreTestExpect",CircuitName("BoreTestTop"))),"x"),
+      NoDedupAnnotation(ModuleName("BoreTestExpect",CircuitName("BoreTestTop"))),
+      RunFirrtlTransformAnnotation(new firrtl.passes.wiring.WiringTransform)
+    )
+
+    annos = (new FirrtlStage).run(annos)
+    val tester = TreadleTester(annos :+ TreadleFirrtlFormHint(LowForm))
+    tester.expect("y", 42)
+    tester.report()
+  }
+}

--- a/src/test/scala/treadle/TesterCreationTest.scala
+++ b/src/test/scala/treadle/TesterCreationTest.scala
@@ -1,0 +1,99 @@
+// See README.md for license details.
+
+package treadle
+
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.TargetDirAnnotation
+import firrtl.{AnnotationSeq, HighFirrtlCompiler, HighForm, LowFirrtlCompiler, LowForm, MidForm, MiddleFirrtlCompiler}
+import firrtl.stage.{CompilerAnnotation, FirrtlCircuitAnnotation, FirrtlSourceAnnotation, FirrtlStage}
+import org.scalatest.{FreeSpec, Matchers}
+import treadle.stage.TreadleTesterPhase
+
+class TesterCreationTest extends FreeSpec with Matchers {
+  "TreadleTester can be created from any form of firrtl" - {
+    //scalastyle:off method.length
+    def testWithCompiler(compilerAnnotation: CompilerAnnotation): Unit = {
+      val readLatency = 1
+      val writeLatency = 1
+      val input =
+        s"""circuit Test :
+           |  module Test :
+           |    input clock    : Clock
+           |    input in1      : UInt<8>
+           |    input addr     : UInt<8>
+           |    input write_en : UInt<1>
+           |    output out1    : UInt<8>
+           |    mem m :
+           |      data-type => UInt<8>
+           |      depth => 32
+           |      read-latency => $readLatency
+           |      write-latency => $writeLatency
+           |      reader => read
+           |      writer => write
+           |
+           |    m.read.clk <= clock
+           |    m.read.en <= eq(write_en, UInt<1>(0))
+           |    m.read.addr <= addr
+           |
+           |    m.write.clk <= clock
+           |    m.write.en <= eq(write_en, UInt<1>(1))
+           |    m.write.mask <= UInt<8>("hff")
+           |    m.write.addr <= addr
+           |    m.write.data <= in1
+           |
+           |    out1 <= m.read.data
+      """.stripMargin
+
+
+      var annos: AnnotationSeq = Seq(
+        TargetDirAnnotation("test_run_dir/tester_creation"),
+        FirrtlSourceAnnotation(input),
+        compilerAnnotation
+      )
+
+      val formHint = TreadleFirrtlFormHint(compilerAnnotation.compiler match {
+        case c: HighFirrtlCompiler   => HighForm
+        case c: MiddleFirrtlCompiler => MidForm
+        case c: LowFirrtlCompiler    => LowForm
+      })
+
+      annos = (new FirrtlStage).run(annos)
+
+      println(
+        s"Post compiler Annotations\n" +
+          annos
+//            .filterNot(_.isInstanceOf[DeletedAnnotation])
+            .map(_.toString.split("\n"))
+            .map { l => l.head + (if(l.length > 1 ) "\n" + l.last else "") }
+            .mkString("\n")
+      )
+
+      annos.exists(_.isInstanceOf[FirrtlCircuitAnnotation]) should be(true)
+      annos.exists(_.isInstanceOf[FirrtlSourceAnnotation]) should be(false)
+
+      annos = TreadleTesterPhase.transform(annos :+ formHint)
+      annos.exists(_.isInstanceOf[TreadleTesterAnnotation]) should be(true)
+
+      println(
+        s"Post Creation Annotations\n" +
+          annos
+          .filterNot(_.isInstanceOf[DeletedAnnotation])
+          .map(_.toString.split("\n"))
+          .map { l => l.head + (if(l.length > 1 ) "\n" + l.last else "") }
+          .mkString("\n")
+      )
+    }
+
+    "Create tester from firrtl circuit with HighFirrtlCompiler" in {
+      testWithCompiler(CompilerAnnotation(new HighFirrtlCompiler))
+    }
+
+    "Create tester from firrtl circuit with MiddleFirrtlCompiler" in {
+      testWithCompiler(CompilerAnnotation(new MiddleFirrtlCompiler))
+    }
+
+    "Create tester from firrtl circuit with LowFirrtlCompiler" in {
+      testWithCompiler(CompilerAnnotation(new LowFirrtlCompiler))
+    }
+  }
+}


### PR DESCRIPTION
- Makes treadle more robust with various forms of firrtl input
- Add Hint that outside programs can identify their firrtl type to treadle
- Add BoreTest to show BoringUtilsSupport
- Add testers creation test to show starting with different forms