### PR TITLE
Revert "Merge pull request #143 from freechipsproject/interval-setp-fix"

### DIFF
--- a/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
+++ b/src/test/scala/treadle/fixedpoint/FixedPointSpec.scala
@@ -66,7 +66,7 @@ class FixedPointSpec extends FlatSpec with Matchers {
         |    output io : {flip in : Fixed<6><<2>>, out : Fixed}
         |
         |    io is invalid
-        |    node T_2 = setp(io.in, 0)
+        |    node T_2 = bpset(io.in, 0)
         |    io.out <= T_2
       """.stripMargin
 


### PR DESCRIPTION
This reverts commit 8e3214073ec088a33b77d801e23e226c3642dda6, reversing
changes made to 5071f74d6092b30023e55cd56e3f0ebe39736baa.

**NOTE**: This is for the upcoming 1.1-20191106-SNAPSHOT, which will be interval-free.