### PR TITLE
Fixes incomplete match specification of a datastore plugin in repl

### DIFF
--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -582,7 +582,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
               plugin.setEnabled(plugin.symbolsToWatch.nonEmpty)
               engine.setLeanMode()
 
-            case None =>
+            case _ =>
               console.println(s"Can't find watch plugin-in")
           }
         }


### PR DESCRIPTION
Tiny fix, tiny problem
But it came up in use.