### PR TITLE
Fixes for problem discovered in riscv-mini

### DIFF
--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -387,28 +387,51 @@ class ExpressionCompiler(
       val arg1Width = getWidth(expressions.head)
       val param1 = ints.head.toInt
 
-      arg1 match {
-        case e1: IntExpressionResult =>
-          op match {
-            case Head => HeadInts(e1.apply _, takeBits = param1, arg1Width)
-            case Tail => TailInts(e1.apply _, toDrop = param1, arg1Width)
-            case Shl  => ShlInts(e1.apply _, GetIntConstant(param1).apply _)
-            case Shr  => ShrInts(e1.apply _, GetIntConstant(param1).apply _)
-          }
-        case e1: LongExpressionResult =>
-          op match {
-            case Head => HeadLongs(e1.apply _, takeBits = param1, arg1Width)
-            case Tail => TailLongs(e1.apply _, toDrop = param1, arg1Width)
-            case Shl  => ShlLongs(e1.apply _, GetLongConstant(param1).apply _)
-            case Shr  => ShrLongs(e1.apply _, GetLongConstant(param1).apply _)
-          }
-        case e1: BigExpressionResult =>
-          op match {
-            case Head => HeadBigs(e1.apply _, takeBits = param1, arg1Width)
-            case Tail => TailBigs(e1.apply _, toDrop = param1, arg1Width)
-            case Shl  => ShlBigs(e1.apply _, GetBigConstant(param1).apply _)
-            case Shr  => ShrBigs(e1.apply _, GetBigConstant(param1).apply _)
-          }
+      if(op == Shl) {
+        (DataSize(getWidth(tpe)), arg1) match {
+          case (IntSize, e1: IntExpressionResult) =>
+            ShlInts(e1.apply _, GetIntConstant(param1).apply _)
+          case (IntSize, e1: LongExpressionResult) =>
+            ShlLongs(e1.apply, GetLongConstant(param1).apply _)
+          case (IntSize, e1: BigExpressionResult) =>
+            ShlBigs(e1.apply _, GetIntConstant(param1).apply _)
+
+          case (LongSize, e1: IntExpressionResult) =>
+            ShlLongs(ToLong(e1.apply _).apply _, GetIntConstant(param1).apply _)
+          case (LongSize, e1: LongExpressionResult) =>
+            ShlLongs(e1.apply _, GetLongConstant(param1).apply _)
+          case (LongSize, e1: BigExpressionResult) =>
+            ShlBigs(e1.apply _, GetBigConstant(param1).apply _)
+
+          case (BigSize, e1: IntExpressionResult) =>
+            ShlBigs(ToBig(e1.apply _).apply _, GetIntConstant(param1).apply _)
+          case (BigSize, e1: LongExpressionResult) =>
+            ShlBigs(LongToBig(e1.apply _).apply _, GetLongConstant(param1).apply _)
+          case (BigSize, e1: BigExpressionResult) =>
+            ShlBigs(e1.apply _, GetBigConstant(param1).apply _)
+        }
+      } else {
+
+        arg1 match {
+          case e1: IntExpressionResult =>
+            op match {
+              case Head => HeadInts(e1.apply _, takeBits = param1, arg1Width)
+              case Tail => TailInts(e1.apply _, toDrop = param1, arg1Width)
+              case Shr => ShrInts(e1.apply _, GetIntConstant(param1).apply _)
+            }
+          case e1: LongExpressionResult =>
+            op match {
+              case Head => HeadLongs(e1.apply _, takeBits = param1, arg1Width)
+              case Tail => TailLongs(e1.apply _, toDrop = param1, arg1Width)
+              case Shr => ShrLongs(e1.apply _, GetLongConstant(param1).apply _)
+            }
+          case e1: BigExpressionResult =>
+            op match {
+              case Head => HeadBigs(e1.apply _, takeBits = param1, arg1Width)
+              case Tail => TailBigs(e1.apply _, toDrop = param1, arg1Width)
+              case Shr => ShrBigs(e1.apply _, GetBigConstant(param1).apply _)
+            }
+        }
       }
     }
 

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -392,23 +392,23 @@ class ExpressionCompiler(
           case (IntSize, e1: IntExpressionResult) =>
             ShlInts(e1.apply _, GetIntConstant(param1).apply _)
           case (IntSize, e1: LongExpressionResult) =>
-            ShlLongs(e1.apply, GetLongConstant(param1).apply _)
+            ShlLongs(e1.apply, GetIntConstant(param1).apply _)
           case (IntSize, e1: BigExpressionResult) =>
             ShlBigs(e1.apply _, GetIntConstant(param1).apply _)
 
           case (LongSize, e1: IntExpressionResult) =>
             ShlLongs(ToLong(e1.apply _).apply _, GetIntConstant(param1).apply _)
           case (LongSize, e1: LongExpressionResult) =>
-            ShlLongs(e1.apply _, GetLongConstant(param1).apply _)
+            ShlLongs(e1.apply _, GetIntConstant(param1).apply _)
           case (LongSize, e1: BigExpressionResult) =>
-            ShlBigs(e1.apply _, GetBigConstant(param1).apply _)
+            ShlBigs(e1.apply _, GetIntConstant(param1).apply _)
 
           case (BigSize, e1: IntExpressionResult) =>
             ShlBigs(ToBig(e1.apply _).apply _, GetIntConstant(param1).apply _)
           case (BigSize, e1: LongExpressionResult) =>
-            ShlBigs(LongToBig(e1.apply _).apply _, GetLongConstant(param1).apply _)
+            ShlBigs(LongToBig(e1.apply _).apply _, GetIntConstant(param1).apply _)
           case (BigSize, e1: BigExpressionResult) =>
-            ShlBigs(e1.apply _, GetBigConstant(param1).apply _)
+            ShlBigs(e1.apply _, GetIntConstant(param1).apply _)
         }
       } else {
 

--- a/src/main/scala/treadle/stage/phases/PrepareAst.scala
+++ b/src/main/scala/treadle/stage/phases/PrepareAst.scala
@@ -47,8 +47,6 @@ class TreadleLowFirrtlOptimization extends SeqTransform {
   def transforms: Seq[Transform] = Seq(
     passes.RemoveValidIf,
     new firrtl.transforms.ConstantPropagation,
-    passes.PadWidths,
-    new firrtl.transforms.ConstantPropagation,
     passes.Legalize,
     new firrtl.transforms.ConstantPropagation,
     passes.SplitExpressions,

--- a/src/test/scala/treadle/primops/ShlShrDshlDshr.scala
+++ b/src/test/scala/treadle/primops/ShlShrDshlDshr.scala
@@ -2,10 +2,10 @@
 
 package treadle.primops
 
+import firrtl.stage.FirrtlSourceAnnotation
 import treadle.executable._
-import treadle.{BitTwiddlingUtils, extremaOfSIntOfWidth, extremaOfUIntOfWidth}
+import treadle.{BitTwiddlingUtils, ShowFirrtlAtLoadAnnotation, TreadleTester, VerboseAnnotation, extremaOfSIntOfWidth, extremaOfUIntOfWidth}
 import org.scalatest.{FreeSpec, Matchers}
-
 
 // scalastyle:off magic.number
 class ShlShrDshlDshr extends FreeSpec with Matchers {
@@ -31,6 +31,48 @@ class ShlShrDshlDshr extends FreeSpec with Matchers {
         staticShifter() should be (staticExpected)
         dynamicShifter() should be (staticExpected)
       }
+    }
+
+    "dynamic shift with constant" in {
+      val input =
+        """
+          |circuit ShiftTest :
+          |  module ShiftTest :
+          |    input clk : Clock
+          |    input reset : UInt<1>
+          |    input  intInput    : UInt<30>
+          |    input  longInput   : UInt<60>
+          |
+          |    output intToLong    : UInt<90>
+          |    output intToBig     : UInt<128>
+          |
+          |    output longToBig    : UInt<90>
+          |
+          |    intToLong    <= dshl(intInput, UInt<7>(32))
+          |    intToBig     <= dshl(intInput, UInt<7>(60))
+          |
+          |    longToBig    <= dshl(longInput, UInt<7>(32))
+
+      """.stripMargin
+
+      val t = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+
+      val intInput = BigInt( "1234", 16)
+      val longInput = BigInt("123456789abc", 16)
+      t.poke("intInput", intInput)
+      t.poke("longInput", longInput)
+
+      val intToLong: BigInt = t.peek("intToLong")
+      val intToBig  = t.peek("intToBig")
+      val longToBig = t.peek("longToBig")
+
+      println(f"intInput  ${intInput.toString(16)} << 32 yields long ${intToLong.toString(16)} with ${intToLong.bitLength}")
+      println(f"intInput  ${intInput.toString(16)} << 60 yields big  ${intToBig.toString(16)}  with ${intToBig.bitLength}")
+      println(f"longInput ${intInput.toString(16)} << 30 yields big  ${longToBig.toString(16)} with ${longToBig.bitLength}")
+
+      t.expect("intToLong", BigInt("123400000000", 16))
+      t.expect("intToBig",  BigInt("1234000000000000000", 16))
+      t.expect("longToBig", BigInt("123456789abc00000000", 16))
     }
 
     "Using UInts" in {


### PR DESCRIPTION
Shl did not handle cases properly when the result crossed over
into the next larger datatype
- Added logic in oneArgOneParam to manage these cases
- This problem does not apply to other primops in this family
- PadWidths removed from TreadleLowFirrtlOptimization
  - recommendation of Albert and Adam
  - possibly contributing to riscv-mini problems
- Added additional tests to check shift left on data size boundaries