### PR TITLE
The vcd filename can be wrong

### DIFF
--- a/src/main/scala/treadle/stage/phases/SetImplicitOutputInfo.scala
+++ b/src/main/scala/treadle/stage/phases/SetImplicitOutputInfo.scala
@@ -31,7 +31,7 @@ object SetImplicitOutputInfo extends Phase {
             state.circuit.main
         }.getOrElse("default")
       }
-      Seq(OutputFileAnnotation(name))
+      Seq(OutputFileAnnotation(outputFileName))
     }
     val targetDir = if(annotationSeq.exists { case _: TargetDirAnnotation => true ; case _ => false }) {
       Seq.empty


### PR DESCRIPTION
In some situations the vcd filename's root string is wrong
This fixes it to be same as other names created in test_run_dir