### PR TITLE
Make printf behavior more closely match verilator

### DIFF
--- a/src/main/scala/treadle/TreadleOptions.scala
+++ b/src/main/scala/treadle/TreadleOptions.scala
@@ -206,6 +206,19 @@ case object CallResetAtStartupAnnotation extends NoTargetAnnotation with Treadle
 }
 
 /**
+  *  Tells treadle to prefix printf strings with a wall time
+  */
+case object PrefixPrintfWithWallTime extends NoTargetAnnotation with TreadleOption with HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "tr-prefix-printf-with-walltime",
+      toAnnotationSeq = _ => Seq(PrefixPrintfWithWallTime),
+      helpText = """Adds a string "[<wall-time>]" to the front of printf lines, helps match to vcd"""
+    )
+  )
+}
+
+/**
   * The circuit used to build a [[TreadleTester]]
   * @param circuit a firrtl ast
   */

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -32,6 +32,8 @@ class ExecutionEngine(
     expressionViews
   )
 
+  scheduler.executionEngineOpt = Some(this)
+
   if(annotationSeq.collectFirst { case ShowFirrtlAtLoadAnnotation => ShowFirrtlAtLoadAnnotation }.isDefined) {
     println(ast.serialize)
   }
@@ -464,6 +466,9 @@ object ExecutionEngine {
       Seq.empty
     )
     val allowCycles = annotationSeq.exists { case AllowCyclesAnnotation => true; case _ => false }
+    val prefixPrintfWithTime = annotationSeq.exists { case PrefixPrintfWithWallTime => true; case _ => false }
+
+
     val rollbackBuffers = annotationSeq.collectFirst{ case RollBackBuffersAnnotation(rbb) => rbb }.getOrElse(
       TreadleDefaults.RollbackBuffers
     )
@@ -486,7 +491,9 @@ object ExecutionEngine {
 
     val scheduler = new Scheduler(symbolTable)
 
-    val compiler = new ExpressionCompiler(symbolTable, dataStore, scheduler, validIfIsRandom, blackBoxFactories)
+    val compiler = new ExpressionCompiler(
+      symbolTable, dataStore, scheduler, validIfIsRandom, prefixPrintfWithTime, blackBoxFactories
+    )
 
     timer("Build Compiled Expressions") {
       compiler.compile(circuit, blackBoxFactories)

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -11,10 +11,11 @@ import treadle.utils.FindModule
 import scala.collection.mutable
 
 class ExpressionCompiler(
-    val symbolTable  : SymbolTable,
-    val dataStore    : DataStore,
-    scheduler        : Scheduler,
-    validIfIsRandom  : Boolean,
+    val symbolTable      : SymbolTable,
+    val dataStore        : DataStore,
+    scheduler            : Scheduler,
+    validIfIsRandom      : Boolean,
+    prefixPrintfWithTime : Boolean,
     blackBoxFactories: Seq[ScalaBlackBoxFactory]
 )
   extends logger.LazyLogging {
@@ -907,7 +908,9 @@ class ExpressionCompiler(
                     getWidth(expression)
                   },
                   clockTransitionGetter,
-                  intExpression
+                  intExpression,
+                  scheduler,
+                  prefixPrintfWithTime
                 )
                 addAssigner(printOp)
               case _ =>

--- a/src/main/scala/treadle/executable/Scheduler.scala
+++ b/src/main/scala/treadle/executable/Scheduler.scala
@@ -25,6 +25,8 @@ class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
 
   private val toAssigner: mutable.HashMap[Symbol, Assigner] = new mutable.HashMap()
 
+  var executionEngineOpt: Option[ExecutionEngine] = None
+
   def addAssigner(
     symbol: Symbol,
     assigner: Assigner,

--- a/src/main/scala/treadle/stage/phases/PrepareAst.scala
+++ b/src/main/scala/treadle/stage/phases/PrepareAst.scala
@@ -113,7 +113,8 @@ object PrepareAst extends TreadlePhase {
       new HighToLow,
       new TreadleLowFirrtlOptimization,
       new BlackBoxSourceHelper,
-      new FixupOps
+      new FixupOps,
+      AugmentPrintf
     )
   }
 }

--- a/src/test/scala/treadle/PrintfCorrectnessSpec.scala
+++ b/src/test/scala/treadle/PrintfCorrectnessSpec.scala
@@ -65,29 +65,33 @@ class PrintfCorrectnessSpec extends FreeSpec with Matchers with LazyLogging {
         |    reg _GEN_7 : UInt<8>, clock with :
         |      reset => (UInt<1>("h0"), UInt<1>("h0")) @[PrintfTreadleVsVerilatorTest.scala 50:9]
         |    _GEN_7 <= tailPointer @[PrintfTreadleVsVerilatorTest.scala 50:9]
-        |    printf(clock, _T_25, "PRINTF:%d moveHead %d, moveTail %d, head %d, tail %d, nextTail %d\n", _GEN_3, moveHead, moveTail, _GEN_6, _GEN_7, nextTail) @[PrintfTreadleVsVerilatorTest.scala 50:9]
+        |    printf(clock, _T_25, "PRINTF:moveHead %d, moveTail %d, head %d, tail %d, nextTail %d\n", moveHead, moveTail, _GEN_6, _GEN_7, nextTail) @[PrintfTreadleVsVerilatorTest.scala 50:9]
         |
         |""".stripMargin
 
     val output = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(output)) {
-      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), WriteVcdAnnotation))
       tester.step()
       tester.poke("moveTail", 1)
+      tester.step()
       tester.step()
       tester.step()
       tester.finish
     }
 
+
+    Logger.setLevel("treadle.PrintfCorrectnessSpec", LogLevel.Debug)
     logger.debug(output.toString)
 
 
+    val outputString = output.toString
     Seq(
-      "PRINTF:   0 moveHead  0, moveTail  0, head    0, tail    0, nextTail    1",
-      "PRINTF:   1 moveHead  0, moveTail  1, head    0, tail    0, nextTail    2",
-      "PRINTF:   2 moveHead  0, moveTail  1, head    0, tail    1, nextTail    3"
+      "PRINTF:moveHead  0, moveTail  0, head    0, tail    0, nextTail    1",
+      "PRINTF:moveHead  0, moveTail  1, head    0, tail    0, nextTail    2",
+      "PRINTF:moveHead  0, moveTail  1, head    0, tail    1, nextTail    3"
     ).foreach { targetLine =>
-      output.toString.contains(targetLine) should be (true)
+      outputString should include (targetLine)
     }
   }
 }

--- a/src/test/scala/treadle/PrintfTimingSpec.scala
+++ b/src/test/scala/treadle/PrintfTimingSpec.scala
@@ -1,0 +1,53 @@
+// See README.md for license details.
+
+package treadle
+
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.{FreeSpec, Matchers}
+
+private class PrintfTimingSpec extends FreeSpec with Matchers {
+  "printf has strict timing requirements" - {
+    "it must fire before registers are updated" in {
+      val input =
+        """
+          |;buildInfoPackage: chisel3, version: 3.2-SNAPSHOT, scalaVersion: 2.12.6, sbtVersion: 1.2.7
+          |circuit Printf1 :
+          |  module Printf1 :
+          |    input clock : Clock
+          |    input reset : UInt<1>
+          |
+          |    reg reg0 : UInt<8>, clock
+          |    reg0 <= add(reg0, UInt(1))
+          |
+          |    node wire0 = add(reg0, UInt(1))
+          |
+          |    printf(clock, UInt<1>(1), "reg0=%x wire0=%x\n", reg0, wire0)
+          |""".stripMargin
+
+      val treadleTester = TreadleTester(Seq(FirrtlSourceAnnotation(input), WriteVcdAnnotation))
+      treadleTester.step(10)
+      treadleTester.finish
+    }
+    "printf every other time based on reg" in {
+      val input =
+        """
+          |;buildInfoPackage: chisel3, version: 3.2-SNAPSHOT, scalaVersion: 2.12.6, sbtVersion: 1.2.7
+          |circuit Printf2 :
+          |  module Printf2 :
+          |    input clock : Clock
+          |    input reset : UInt<1>
+          |
+          |    reg reg0 : UInt<8>, clock
+          |    reg0 <= add(reg0, UInt(1))
+          |
+          |    node enable = eq(mod(reg0, UInt(4)), UInt(0))
+          |
+          |    printf(clock, enable, "reg0=%x\n", reg0)
+          |""".stripMargin
+
+      val treadleTester = TreadleTester(Seq(FirrtlSourceAnnotation(input), WriteVcdAnnotation))
+      treadleTester.step(10)
+      treadleTester.finish
+    }
+  }
+}


### PR DESCRIPTION
- Was sometimes off a cycle when using a non-constant enable
- Give printf access to testers wall time to make it easier to match printf to vcd
- Make printf format look a bit more like verilator
- Tangled up with this was some diagnostic code
  - Add an option PrefixPrintfWithWallTime
  - Adds a walltime field to the front of each printf statement
  - This really helps with matching up printfs to VCD views
- There remains a problem with the printf when the reset has gone low at the same time as the clock going high.