### PR TITLE
Allows setting the initial phase offset for the clock to zero

### DIFF
--- a/src/main/scala/treadle/executable/ClockInfo.scala
+++ b/src/main/scala/treadle/executable/ClockInfo.scala
@@ -40,7 +40,7 @@ case class ClockInfo(
 
   val upPeriod:   Long = period / 2
   val downPeriod: Long = period - upPeriod
-  if (initialOffset <= 0) {
+  if (initialOffset < 0) {
     throw TreadleException(s"initialOffset in ClockInfo for $name must be positive. Found value $initialOffset")
   }
 


### PR DESCRIPTION
so that simulation starts with clock high.
@johnsbrew reports testing scenarios where it is desirable to start simulation with clock high
See: [chisel-testers/issues/280](https://github.com/freechipsproject/chisel-testers/issues/280)