### PR TITLE
VCD fixes and improvements

### DIFF
--- a/src/main/scala/treadle/executable/DataStorePlugIn.scala
+++ b/src/main/scala/treadle/executable/DataStorePlugIn.scala
@@ -98,13 +98,15 @@ class RenderComputations(
   }
 }
 
-class VcdHook(val executionEngine: ExecutionEngine, val vcd: VCD) extends DataStorePlugin {
+class VcdHook(val executionEngine: ExecutionEngine) extends DataStorePlugin {
   val dataStore: DataStore = executionEngine.dataStore
 
   override def run(symbol: Symbol, offset: Int = -1, previousValue: BigInt): Unit = {
     if (offset == -1) {
       val value = dataStore(symbol)
-      vcd.wireChanged(symbol.name, value, width = symbol.bitWidth)
+      executionEngine.vcdOption.foreach { vcd =>
+        vcd.wireChanged(symbol.name, value, width = symbol.bitWidth)
+      }
     }
   }
 }

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -136,7 +136,7 @@ class ExecutionEngine(
     vcdOption = Some(vcd)
     vcdFileName = fileName
 
-    val vcdPlugIn = new VcdHook(this, vcd)
+    val vcdPlugIn = new VcdHook(this)
     dataStore.addPlugin(ExecutionEngine.VCDHookName, vcdPlugIn, enable = true)
   }
 

--- a/src/main/scala/treadle/vcd/diff/VcdComparator.scala
+++ b/src/main/scala/treadle/vcd/diff/VcdComparator.scala
@@ -35,9 +35,9 @@ object VcdComparator {
 //scalastyle:off magic.number
 class VcdComparator(annotationSeq: AnnotationSeq) {
   val ignoreTempWires:      Boolean = annotationSeq.exists { case IgnoreTempWires => true; case _ => false }
-  val doCompareDirectories: Boolean = annotationSeq.exists { case CompareWires => true; case _ => false }
-  val doUnmatchedWires:     Boolean = annotationSeq.exists { case UnmatchedWires => true; case _ => false }
-  val dontDiffValues:       Boolean = annotationSeq.exists { case DontDiffValues => true; case _ => false }
+  val doCompareDirectories: Boolean = annotationSeq.exists { case CompareWires    => true; case _ => false }
+  val doUnmatchedWires:     Boolean = annotationSeq.exists { case UnmatchedWires  => true; case _ => false }
+  val dontDiffValues:       Boolean = annotationSeq.exists { case DontDiffValues  => true; case _ => false }
 
   private val (removePrefix1, addPrefix1) = annotationSeq.collectFirst {
     case wp: WirePrefix1 => (wp.removePrefix, wp.addPrefix)
@@ -119,25 +119,23 @@ class VcdComparator(annotationSeq: AnnotationSeq) {
     val (vcd1CodeToVcd2Code, vcd2CodeToVcd1Code) = buildVcd1CodeToVcd2Code()
 
     def showMatchedCodes(): Unit = {
-      vcd1CodeToVcd2Code
-        .toSeq
-        .map {
-          case (tag1, tag2) =>
-            val name1 = vcd1.wires(tag1).fullName
-            val name2 = vcd2.wires(tag2).fullName
-            (tag1, tag2, name1, name2)
-      }.sortWith { case ((_, _, a, _), (_, _, b, _)) => a < b}
-        .foreach { case (tag1, tag2, name1, name2) =>
+      vcd1CodeToVcd2Code.toSeq.map {
+        case (tag1, tag2) =>
+          val name1 = vcd1.wires(tag1).fullName
+          val name2 = vcd2.wires(tag2).fullName
+          (tag1, tag2, name1, name2)
+      }.sortWith { case ((_, _, a, _), (_, _, b, _)) => a < b }.foreach {
+        case (tag1, tag2, name1, name2) =>
           println(f"$tag1%5s $tag2%5s --- $name1 $name2")
-        }
+      }
     }
 
     trait NextOption[T] { self: Iterator[T] =>
-      def nextOption: Option[T] = if(hasNext) {Some(next())} else {None}
+      def nextOption: Option[T] = if (hasNext) { Some(next()) } else { None }
     }
 
     def showUnmatchedWires(): Unit = {
-      def nextOption(i: Iterator[String]): Option[String] = if(i.hasNext) {Some(i.next())} else {None}
+      def nextOption(i: Iterator[String]): Option[String] = if (i.hasNext) { Some(i.next()) } else { None }
 
       def show(nameOpt1: Option[String], nameOpt2: Option[String]): Unit = {
         println(f"${nameOpt1.getOrElse("---")}%60s ${nameOpt2.getOrElse("---")}%-60s")
@@ -150,11 +148,11 @@ class VcdComparator(annotationSeq: AnnotationSeq) {
       while (name1.isDefined || name2.isDefined) {
         (name1, name2) match {
           case (Some(n1), Some(n2)) =>
-            if(n1 == n2) {
+            if (n1 == n2) {
               show(name1, name2)
               name1 = nextOption(i1)
               name2 = nextOption(i2)
-            } else if(n1 < n2) {
+            } else if (n1 < n2) {
               show(name1, None)
               name1 = nextOption(i1)
             } else {
@@ -168,7 +166,6 @@ class VcdComparator(annotationSeq: AnnotationSeq) {
             show(name1, name2)
             name2 = nextOption(i2)
           case _ =>
-
         }
       }
     }
@@ -176,10 +173,10 @@ class VcdComparator(annotationSeq: AnnotationSeq) {
     /** Iterate through both sets of changes recording those who do not match */
     def compareChangeSets(set1: List[Change], set2: List[Change], time: Long): Unit = {
       val changeCodes1 = set1.map { change =>
-        change.wire.id -> change
+        change.wire.fullName -> change
       }.toMap
       val changeCodes2 = set2.map { change =>
-        change.wire.id -> change
+        change.wire.fullName -> change
       }.toMap
       var timeShown = false
 
@@ -279,7 +276,7 @@ class VcdComparator(annotationSeq: AnnotationSeq) {
 
       def dumpWires(wires: Seq[String], fileName: String) {
         val out = new PrintStream(new File(fileName))
-        for(name <- wires) {
+        for (name <- wires) {
           out.println(name)
         }
         out.close()

--- a/src/test/scala/treadle/vcd/VCDSpec.scala
+++ b/src/test/scala/treadle/vcd/VCDSpec.scala
@@ -107,8 +107,6 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
     vcd.valuesAtTime(4).size should be(1)
     vcd.valuesAtTime(5).size should be(3)
     vcd.valuesAtTime(6).size should be(1)
-
-    println(vcd.serialize)
   }
 
   it should "be able to serialize negative and positive values" in {

--- a/src/test/scala/treadle/vcd/VcdRoundTripTest.scala
+++ b/src/test/scala/treadle/vcd/VcdRoundTripTest.scala
@@ -1,0 +1,124 @@
+// See README.md for license details.
+
+package treadle.vcd
+
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.{FreeSpec, Matchers}
+import treadle.{TreadleTester, WriteVcdAnnotation}
+
+class VcdRoundTripTest extends FreeSpec with Matchers {
+  "create a vcd through treadle and then read it back in" in {
+    val input =
+      """
+        |;buildInfoPackage: chisel3, version: 3.3-SNAPSHOT, scalaVersion: 2.12.10, sbtVersion: 1.3.2
+        |circuit TopModule :
+        |  module ModuleA :
+        |    input clock : Clock
+        |    input reset : Reset
+        |    input a : UInt<16>
+        |    input b : UInt<16>
+        |    output c : UInt<16>
+        |
+        |    node _T = add(a, b) @[HierarchicalNaming.scala 23:23]
+        |    node _T_1 = tail(_T, 1) @[HierarchicalNaming.scala 23:23]
+        |    reg _T_2 : UInt, clock @[HierarchicalNaming.scala 23:20]
+        |    _T_2 <= _T_1 @[HierarchicalNaming.scala 23:20]
+        |    c <= _T_2 @[HierarchicalNaming.scala 24:7]
+        |
+        |  module ModuleA_1 :
+        |    input clock : Clock
+        |    input reset : Reset
+        |    input a : UInt<16>
+        |    input b : UInt<16>
+        |    output c : UInt<16>
+        |
+        |    inst ModuleA of ModuleA @[HierarchicalNaming.scala 18:19]
+        |    ModuleA.clock <= clock
+        |    ModuleA.reset <= reset
+        |    ModuleA.a <= a @[HierarchicalNaming.scala 19:9]
+        |    ModuleA.b <= b @[HierarchicalNaming.scala 20:9]
+        |    c <= ModuleA.c @[HierarchicalNaming.scala 21:7]
+        |
+        |  module ModuleA_2 :
+        |    input clock : Clock
+        |    input reset : Reset
+        |    input a : UInt<16>
+        |    input b : UInt<16>
+        |    output c : UInt<16>
+        |
+        |    inst ModuleA of ModuleA_1 @[HierarchicalNaming.scala 18:19]
+        |    ModuleA.clock <= clock
+        |    ModuleA.reset <= reset
+        |    ModuleA.a <= a @[HierarchicalNaming.scala 19:9]
+        |    ModuleA.b <= b @[HierarchicalNaming.scala 20:9]
+        |    c <= ModuleA.c @[HierarchicalNaming.scala 21:7]
+        |
+        |  module ModuleA_3 :
+        |    input clock : Clock
+        |    input reset : Reset
+        |    input a : UInt<16>
+        |    input b : UInt<16>
+        |    output c : UInt<16>
+        |
+        |    node _T = add(a, b) @[HierarchicalNaming.scala 23:23]
+        |    node _T_1 = tail(_T, 1) @[HierarchicalNaming.scala 23:23]
+        |    reg _T_2 : UInt, clock @[HierarchicalNaming.scala 23:20]
+        |    _T_2 <= _T_1 @[HierarchicalNaming.scala 23:20]
+        |    c <= _T_2 @[HierarchicalNaming.scala 24:7]
+        |
+        |  module TopModule :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    input topA : UInt<16>
+        |    input topB : UInt<16>
+        |    output topC : UInt<16>
+        |
+        |    inst mpath2 of ModuleA_2 @[HierarchicalNaming.scala 33:22]
+        |    mpath2.clock <= clock
+        |    mpath2.reset <= reset
+        |    inst mpath0 of ModuleA_3 @[HierarchicalNaming.scala 34:22]
+        |    mpath0.clock <= clock
+        |    mpath0.reset <= reset
+        |    mpath2.a <= topA @[HierarchicalNaming.scala 36:12]
+        |    mpath2.b <= topB @[HierarchicalNaming.scala 37:12]
+        |    mpath0.a <= topA @[HierarchicalNaming.scala 38:12]
+        |    mpath0.b <= topB @[HierarchicalNaming.scala 39:12]
+        |    node _T = add(mpath2.c, mpath0.c) @[HierarchicalNaming.scala 41:20]
+        |    node _T_1 = tail(_T, 1) @[HierarchicalNaming.scala 41:20]
+        |    topC <= _T_1 @[HierarchicalNaming.scala 41:8]
+        |
+        |
+        |""".stripMargin
+
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), WriteVcdAnnotation))
+
+    for {
+      a <- (3 until 10)
+      b <- (7 until 22)
+    } {
+      tester.poke("topA", a)
+      tester.poke("topB", b)
+      tester.step()
+
+      // println(s"f(a = $a,  b = $b) => ${tester.peek("topC")}")
+    }
+
+    tester.report()
+
+    val readVcd = VCD.read("test_run_dir/TopModule/TopModule.vcd")
+    val madeVcd = tester.engine.vcdOption.get
+
+    val madeKeys = madeVcd.wires.keys.toSeq.sorted
+    val readKeys = readVcd.wires.keys.toSeq.sorted
+
+    madeKeys.zip(readKeys).foreach {
+      case (k1, k2) =>
+        k1 should be(k2)
+    }
+
+    madeKeys.foreach { key =>
+      readVcd.wires(key).fullName should be(madeVcd.wires(key).fullName)
+      println(f"${readVcd.wires(key).fullName}%60s  ===  ${madeVcd.wires(key).fullName}")
+    }
+  }
+}


### PR DESCRIPTION
- The VCD writer now uses the engines current vcd  - Instead of using a cached reference that could go stale.
- A VCD read from a file and VCD created by treadle were not using the same lookup convention to find signals
  - this has been fixed
- Renamed wires to wiredIdToWire to make it clear how it was used.
- Scopes were not being correctly used during Wire creation in generated VCD.
- VCD now writes itself directly to a file instead of building an entire text image in memory
  - This makes it faster, use less memory, it could fail for large files previous to this.
- Added new test that VCD read from file matches the internal one generated by a treadle run
- Added a convenience method `dumpHumanReadable` that prints out a moderately pretty version of a VCD
  - this code already existed, just made it a callable method