### PR TITLE
Return to using LowFirrtlOptimization

### DIFF
--- a/src/main/scala/treadle/executable/Memory.scala
+++ b/src/main/scala/treadle/executable/Memory.scala
@@ -17,13 +17,35 @@ limitations under the License.
 package treadle.executable
 
 import treadle._
-import firrtl.{MemKind, WireKind}
-import firrtl.ir.{ClockType, DefMemory, Info, IntWidth}
+import firrtl.{FileUtils, MemKind, RegKind, WireKind}
+import firrtl.ir.{ClockType, DefMemory, Info, IntWidth, ReadUnderWrite}
 import RenderHelper.ExpressionHelper
 import firrtl.annotations.{ComponentName, LoadMemoryAnnotation, MemoryLoadFileType, ModuleName}
 
 import scala.collection.mutable
 
+////////////////////////////////////////////////////////////////////////////////
+// IMPORTANT NOTE
+// The primary methods here have been effectively disabled by using
+//     val memory = defMemory.copy(readLatency = 0, writeLatency = 0,
+//         readUnderWrite = ReadUnderWrite.Undefined)
+// appearing at the beginning. This is because the functionality contained here,
+// i.e. adding read and write pipeline registers is now being taken care of in the
+// VerilogMemDelays transform in the LowFirrtlOptimization. This may or may not
+// be the long term solution. So the code here will remain here but disabled for now.
+// Though it is still used to do the trivial case of hooking up memory ports to the
+// wires
+////////////////////////////////////////////////////////////////////////////////
+
+/** Provides three different aspects of the code necessary to create read and write
+  * register pipelines. The three cases are:
+  *  - Adding the symbols for the registers to be created
+  *  - Adding the rendering code necessary to Expression views of the pipelines
+  *  - Actually adding the pipeline registers.
+  *
+  *  NOTE: See IMPORTANT NOTE above.
+  *
+  */
 object Memory {
   //scalastyle:off method.length
   /**
@@ -31,17 +53,19 @@ object Memory {
     * Pipelines are constructed as registers with a regular name and
     * a /in name.  Data travels up-index through a pipeline for both
     * read and write pipelines.
-    * @param memory                  the specified memory
+    * @param defMemory               the specified memory
     * @param expandedName            the full name of the memory
     * @param sensitivityGraphBuilder external graph of dependencies
     * @return
     */
   def buildSymbols(
-    memory:                  DefMemory,
+    defMemory:               DefMemory,
     expandedName:            String,
     sensitivityGraphBuilder: SensitivityGraphBuilder,
     registerNames:           mutable.HashSet[String]
   ): Seq[Symbol] = {
+    val memory = defMemory.copy(readLatency = 0, writeLatency = 0, readUnderWrite = ReadUnderWrite.Undefined)
+
     if (memory.depth >= BigInt(Int.MaxValue)) {
       throw TreadleException(s"Memory $expandedName size ${memory.depth} is too large for treadle")
     }
@@ -53,9 +77,11 @@ object Memory {
 
     val lastValueSymbols = new mutable.ArrayBuffer[Symbol]()
 
+    val effectiveReadLatency = memory.readLatency + (if (memory.readUnderWrite == ReadUnderWrite.New) 1 else 0)
+
     def buildRegisterTriple(baseName: String, index: Int, dataType: firrtl.ir.Type): Seq[Symbol] = {
 
-      val register = Symbol(s"$baseName$index", dataType, WireKind)
+      val register = Symbol(s"$baseName$index", dataType, RegKind)
       registerNames += register.name
       val registerIn = SymbolTable.makeRegisterInputSymbol(register)
       val lastClockValue = SymbolTable.makeLastValueSymbol(register)
@@ -104,10 +130,10 @@ object Memory {
 
       sensitivityGraphBuilder.addSensitivity(clk, data)
 
-      val pipelineRaddrSymbols = (0 until memory.readLatency).flatMap { n =>
+      val pipelineRaddrSymbols = (0 until effectiveReadLatency).flatMap { n =>
         buildRegisterTriple(s"$expandedName.$readerString.pipeline_raddr_", n, addrType)
       }
-      val pipelineEnableSymbols = (0 until memory.readLatency).flatMap { n =>
+      val pipelineEnableSymbols = (0 until effectiveReadLatency).flatMap { n =>
         buildRegisterTriple(s"$expandedName.$readerString.pipeline_ren_", n, booleanType)
       }
 
@@ -175,12 +201,12 @@ object Memory {
       sensitivityGraphBuilder.addSensitivity(mode, valid)
       sensitivityGraphBuilder.addSensitivity(mask, valid)
 
-      val pipelineReadDataSymbols = (0 until memory.readLatency).flatMap { n =>
+      val pipelineReadDataSymbols = (0 until effectiveReadLatency).flatMap { n =>
         buildRegisterTriple(s"$expandedName.$readWriterString.pipeline_raddr_", n, addrType)
       }
       buildPipelineDependencies(addr, pipelineReadDataSymbols, Some(rdata), clockSymbol = Some(clk))
 
-      val pipelineReadEnableSymbols = (0 until memory.readLatency).flatMap { n =>
+      val pipelineReadEnableSymbols = (0 until effectiveReadLatency).flatMap { n =>
         buildRegisterTriple(s"$expandedName.$readWriterString.pipeline_ren_", n, booleanType)
       }
       buildPipelineDependencies(addr, pipelineReadEnableSymbols, Some(rdata), clockSymbol = Some(clk))
@@ -215,18 +241,19 @@ object Memory {
 
   /**
     * Construct views for all the memory elements
-    * @param memory       current memory
+    * @param defMemory    current memory
     * @param expandedName full path name
     * @param scheduler    handle to execution components
     * @param expressionViews   where to store the generated views
     */
   def buildMemoryExpressions(
-    memory:       DefMemory,
+    defMemory:    DefMemory,
     expandedName: String,
     scheduler:    Scheduler,
 //    compiler     : ExpressionCompiler,
     expressionViews: mutable.HashMap[Symbol, ExpressionView]
   ): Unit = {
+    val memory = defMemory.copy(readLatency = 0, writeLatency = 0, readUnderWrite = ReadUnderWrite.Undefined)
 
     val symbolTable = scheduler.symbolTable
     val memorySymbol = symbolTable(expandedName)
@@ -269,7 +296,9 @@ object Memory {
       enable:       Symbol
     ): Symbol = {
 
-      val pipelineReadSymbols = buildPipeLine(portName, pipelineName, memory.readLatency)
+      val effectiveReadLatency = memory.readLatency + (if (memory.readUnderWrite == ReadUnderWrite.New) 1 else 0)
+
+      val pipelineReadSymbols = buildPipeLine(portName, pipelineName, effectiveReadLatency)
       val chain = Seq(addr) ++ pipelineReadSymbols
 
       // This produces triggered: reg0 <= reg0/in, reg1 <= reg1/in etc.
@@ -391,17 +420,19 @@ object Memory {
 
   /**
     * Construct the machinery to move data into and out of the memory stack
-    * @param memory       current memory
+    * @param defMemory    current memory
     * @param expandedName full path name
     * @param scheduler    handle to execution components
     * @param compiler     needed for assigner generation
     */
   def buildMemoryInternals(
-    memory:       DefMemory,
+    defMemory:    DefMemory,
     expandedName: String,
     scheduler:    Scheduler,
     compiler:     ExpressionCompiler
   ): Unit = {
+    val memory = defMemory.copy(readLatency = 0, writeLatency = 0, readUnderWrite = ReadUnderWrite.Undefined)
+
     val symbolTable = scheduler.symbolTable
     val memorySymbol = symbolTable(expandedName)
     val dataStore = compiler.dataStore
@@ -482,8 +513,10 @@ object Memory {
       val addr = symbolTable(s"$name.addr")
       val data = symbolTable(s"$name.data")
 
-      val endOfAddrPipeline = buildPipelineAssigners(clock, addr, name, "raddr", memory.readLatency, memory.info)
-      val endOfEnablePipeline = buildPipelineAssigners(clock, enable, name, "ren", memory.readLatency, memory.info)
+      val effectiveReadLatency = memory.readLatency + (if (memory.readUnderWrite == ReadUnderWrite.New) 1 else 0)
+
+      val endOfAddrPipeline = buildPipelineAssigners(clock, addr, name, "raddr", effectiveReadLatency, memory.info)
+      val endOfEnablePipeline = buildPipelineAssigners(clock, enable, name, "ren", effectiveReadLatency, memory.info)
 
       compiler.makeAssigner(
         data,
@@ -601,7 +634,7 @@ class MemoryInitializer(engine: ExecutionEngine) {
   }
 
   private def doInitialize(memorySymbol: Symbol, fileName: String, radix: Int): Unit = {
-    io.Source.fromFile(fileName).getLines().zipWithIndex.foreach {
+    FileUtils.getLines(fileName).zipWithIndex.foreach {
       case (line, lineNumber) if lineNumber < memorySymbol.slots =>
         try {
           val value = BigInt(line.trim, radix)

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -160,7 +160,7 @@ object SymbolTable extends LazyLogging {
   def makeRegisterInputName(name:     String): String = name + RegisterInputSuffix
   def makeRegisterInputName(symbol:   Symbol): String = symbol.name + RegisterInputSuffix
   def makeRegisterInputSymbol(symbol: Symbol): Symbol = {
-    Symbol(makeRegisterInputName(symbol), symbol.firrtlType, WireKind, info = symbol.info)
+    Symbol(makeRegisterInputName(symbol), symbol.firrtlType, RegKind, info = symbol.info)
   }
 
   def makeLastValueName(name:   String): String = name + LastValueSuffix

--- a/src/main/scala/treadle/stage/phases/PrepareAst.scala
+++ b/src/main/scala/treadle/stage/phases/PrepareAst.scala
@@ -29,6 +29,7 @@ import firrtl.{
   CircuitForm,
   CircuitState,
   HighForm,
+  LowFirrtlOptimization,
   LowForm,
   SeqTransform,
   Transform,
@@ -134,7 +135,7 @@ object PrepareAst extends TreadlePhase {
     Seq(
       new ChirrtlToLow,
       new HighToLow,
-      new TreadleLowFirrtlOptimization,
+      new LowFirrtlOptimization,
       new BlackBoxSourceHelper,
       new FixupOps,
       AugmentPrintf

--- a/src/test/scala/treadle/ClockSpec.scala
+++ b/src/test/scala/treadle/ClockSpec.scala
@@ -120,7 +120,7 @@ class ClockSpec extends FreeSpec with Matchers {
       println(s"memory($i) = ${tester.peekMemory("m", i)}")
     }
     // read phase
-    tester.poke("write_en", 1)
+    tester.poke("write_en", 0)
     for (i <- 0 until 8) {
       tester.poke("addr", i)
       tester.expect("out1", i * 10 + i)

--- a/src/test/scala/treadle/MemoryUsageSpec.scala
+++ b/src/test/scala/treadle/MemoryUsageSpec.scala
@@ -22,6 +22,7 @@ import firrtl.FileUtils
 import firrtl.annotations.{CircuitName, ComponentName, LoadMemoryAnnotation, ModuleName}
 import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.{FreeSpec, Matchers}
+import treadle.executable.StopException
 
 /**
   * Created by chick on 4/30/16.
@@ -307,7 +308,7 @@ class MemoryUsageSpec extends FreeSpec with Matchers {
     tester.poke("in1", 11)
     tester.poke("addr", 3)
     tester.poke("write_en", 1)
-    tester.expectMemory("m", 3, 0)
+    tester.expectMemory("m", 3, 11)
 
     tester.step()
 
@@ -450,7 +451,7 @@ class MemoryUsageSpec extends FreeSpec with Matchers {
     tester.finish
   }
 
-  val simpleMem =
+  private val simpleMem =
     s"""
        |circuit a :
        |  module a :
@@ -519,5 +520,75 @@ class MemoryUsageSpec extends FreeSpec with Matchers {
     tester.poke("io_r_en", 0)
     tester.step()
     tester.peek("m.r.en") should be(0)
+  }
+
+  "SyncReadMem write collision behaviors should work" in {
+    val input =
+      """
+        |;buildInfoPackage: chisel3, version: 3.3-SNAPSHOT, scalaVersion: 2.12.10, sbtVersion: 1.3.8
+        |circuit SyncReadMemWriteCollisionTester :
+        |  module SyncReadMemWriteCollisionTester :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output io : {}
+        |
+        |    reg cnt : UInt<3>, clock with : (reset => (reset, UInt<3>("h00"))) @[Counter.scala 29:33]
+        |    when UInt<1>("h01") : @[Counter.scala 71:17]
+        |      node _T = eq(cnt, UInt<3>("h04")) @[Counter.scala 37:24]
+        |      node _T_1 = add(cnt, UInt<1>("h01")) @[Counter.scala 38:22]
+        |      node _T_2 = tail(_T_1, 1) @[Counter.scala 38:22]
+        |      cnt <= _T_2 @[Counter.scala 38:13]
+        |      when _T : @[Counter.scala 40:21]
+        |        cnt <= UInt<1>("h00") @[Counter.scala 40:29]
+        |        skip @[Counter.scala 40:21]
+        |      skip @[Counter.scala 71:17]
+        |    node _T_3 = and(UInt<1>("h01"), _T) @[Counter.scala 72:20]
+        |    smem m0 : UInt<2>[2], new @[Mem.scala 40:23]
+        |    node _T_4 = bits(cnt, 0, 0) @[Mem.scala 41:20]
+        |    read mport rd0 = m0[_T_4], clock @[Mem.scala 41:20]
+        |    node _T_5 = bits(cnt, 0, 0)
+        |    write mport _T_6 = m0[_T_5], clock
+        |    _T_6 <= cnt
+        |    smem m1 : UInt<2>[2], old @[Mem.scala 45:23]
+        |    node _T_7 = bits(cnt, 0, 0) @[Mem.scala 46:20]
+        |    read mport rd1 = m1[_T_7], clock @[Mem.scala 46:20]
+        |    node _T_8 = bits(cnt, 0, 0)
+        |    write mport _T_9 = m1[_T_8], clock
+        |    _T_9 <= cnt
+        |    node _T_10 = eq(cnt, UInt<2>("h03")) @[Mem.scala 50:13]
+        |    when _T_10 : @[Mem.scala 50:22]
+        |      node _T_11 = eq(rd0, UInt<2>("h02")) @[Mem.scala 51:16]
+        |      node _T_12 = bits(reset, 0, 0) @[Mem.scala 51:11]
+        |      node _T_13 = or(_T_11, _T_12) @[Mem.scala 51:11]
+        |      node _T_14 = eq(_T_13, UInt<1>("h00")) @[Mem.scala 51:11]
+        |      when _T_14 : @[Mem.scala 51:11]
+        |        printf(clock, UInt<1>(1), "Assertion failed\n    at Mem.scala:51 assert(rd0 === 2.U)\n") @[Mem.scala 51:11]
+        |        stop(clock, UInt<1>(1), 1) @[Mem.scala 51:11]
+        |        skip @[Mem.scala 51:11]
+        |      node _T_15 = eq(rd1, UInt<1>("h00")) @[Mem.scala 52:16]
+        |      node _T_16 = bits(reset, 0, 0) @[Mem.scala 52:11]
+        |      node _T_17 = or(_T_15, _T_16) @[Mem.scala 52:11]
+        |      node _T_18 = eq(_T_17, UInt<1>("h00")) @[Mem.scala 52:11]
+        |      when _T_18 : @[Mem.scala 52:11]
+        |        printf(clock, UInt<1>(1), "Assertion failed\n    at Mem.scala:52 assert(rd1 === 0.U)\n") @[Mem.scala 52:11]
+        |        stop(clock, UInt<1>(1), 1) @[Mem.scala 52:11]
+        |        skip @[Mem.scala 52:11]
+        |      skip @[Mem.scala 50:22]
+        |    node _T_19 = eq(cnt, UInt<3>("h04")) @[Mem.scala 55:13]
+        |    when _T_19 : @[Mem.scala 55:22]
+        |      node _T_20 = bits(reset, 0, 0) @[Mem.scala 56:9]
+        |      node _T_21 = eq(_T_20, UInt<1>("h00")) @[Mem.scala 56:9]
+        |      when _T_21 : @[Mem.scala 56:9]
+        |        stop(clock, UInt<1>(1), 0) @[Mem.scala 56:9]
+        |        skip @[Mem.scala 56:9]
+        |      skip @[Mem.scala 55:22]
+        |
+        |""".stripMargin
+
+    val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input), WriteVcdAnnotation, ShowFirrtlAtLoadAnnotation))
+
+    intercept[StopException] {
+      tester.step(100)
+    }
   }
 }


### PR DESCRIPTION
This will invoke VerilogMemDelays transform that will build
register piplelines, instead of having treadle do it.
This PR changes Memory.scala, to set all latencies to zero
to rely on what was assembled by the VerilogMemDelays.
I'm keeping all the machinery to build these pipelines in Memory.scala since there is a // Todo on VerilogMemDelays in
LowFirrtlOptimization to move it to verilog emitter.

This includes a fix for registers created by Memory to be RegKind instead of WireKind