### PR TITLE
Augmented combinational loop report

### DIFF
--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -567,6 +567,50 @@ object SymbolTable extends LazyLogging {
         throw TreadleException(s"Top level module is not the right kind of module $x")
     }
 
+    /* This builds an expression view system then uses that
+     * to do a better job of showing the loop
+     */
+    def showLoop(badNode: Symbol, symbolTable: SymbolTable): Unit = {
+      val dummyDatastore = new DataStore(10, new DataStoreAllocator)
+      val expressionViews = ExpressionViewBuilder.getExpressionViews(
+        symbolTable,
+        dummyDatastore,
+        new Scheduler(symbolTable),
+        validIfIsRandom = false,
+        circuit,
+        blackBoxFactories
+      )
+      val expressionViewRenderer = new ExpressionViewRenderer(
+        dummyDatastore,
+        symbolTable,
+        expressionViews,
+        maxDependencyDepth = 0
+      )
+
+      def show(symbol: Symbol, highlightPattern: String): Unit = {
+        val expr = expressionViewRenderer.render(symbol, 0L, showValues = false)
+        val line = s"$expr   : ${symbol.info.serialize}"
+        val highlighted = line.replace(highlightPattern, s"${Console.RED}$highlightPattern${Console.RESET}")
+        println(highlighted)
+      }
+
+      val badChildren = symbolTable.getChildren(Seq(badNode))
+      badChildren.exists { node =>
+        try {
+          val path = symbolTable.childrenOf.path(node, badNode) ++ symbolTable.childrenOf.path(badNode, node).tail
+          println(s"Problem path found starting at ${node.name}")
+          path.reverse.zip(path.reverse.tail).foreach {
+            case (symbol, nextSymbol) =>
+              show(symbol, nextSymbol.name)
+          }
+          true
+        } catch {
+          case t: Throwable =>
+            false
+        }
+      }
+    }
+
     logger.trace(s"Build SymbolTable pass 1 -- gather starting")
     processModule("", module)
     logger.trace(s"Build SymbolTable pass 1 -- gather complete: ${nameToSymbol.size} entries found")
@@ -598,18 +642,11 @@ object SymbolTable extends LazyLogging {
         if (allowCycles) {
           symbolTable.symbols.toSeq
         } else {
-          symbolTable.getChildren(Seq(badNode)).exists { node =>
-            try {
-              val path = symbolTable.childrenOf.path(node, badNode)
-              println(s"Problem path:\n  ${badNode.name}\n  ${path.map(_.name).mkString("\n  ")}")
-              true
-            } catch {
-              case _: Throwable =>
-                false
-            }
-          }
+          showLoop(badNode, symbolTable)
           throw e
         }
+      case t: Throwable =>
+        throw t
     }
     logger.trace(s"Build SymbolTable pass 2 -- linearize complete")
 

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -21,13 +21,12 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import firrtl.graph.CyclicException
 import firrtl.stage.FirrtlSourceAnnotation
 import firrtl.transforms.DontCheckCombLoopsAnnotation
-import logger.{LazyLogging, LogLevel, Logger}
 import treadle._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 //scalastyle:off magic.number
-class SymbolTableSpec extends AnyFreeSpec with Matchers with LazyLogging {
+class SymbolTableSpec extends AnyFreeSpec with Matchers {
   """SymbolTable creates a table with dependency information""" in {
     val simpleFirrtl: String =
       s"""
@@ -66,14 +65,14 @@ class SymbolTableSpec extends AnyFreeSpec with Matchers with LazyLogging {
     symbolTable.registerNames.toList.sorted.foreach { key =>
       val dependents = symbolTable.childrenOf.reachableFrom(symbolTable(key))
 
-      logger.info(s"$key => ${dependents.map(_.name).mkString(",")}")
+      println(s"$key => ${dependents.map(_.name).mkString(",")}")
     }
 
-    logger.info("All dependencies")
+    println("All dependencies")
     symbolTable.symbols.toList.sortBy(_.name).foreach { keySymbol =>
       val dependents = symbolTable.childrenOf.reachableFrom(keySymbol)
 
-      logger.info(s"${keySymbol.name} => ${dependents.map(_.name).mkString(",")}")
+      println(s"${keySymbol.name} => ${dependents.map(_.name).mkString(",")}")
     }
   }
 
@@ -104,11 +103,11 @@ class SymbolTableSpec extends AnyFreeSpec with Matchers with LazyLogging {
 
     childrenOf.reachableFrom(symbolTable("io_in1")) should contain(symbolTable("io_out1"))
 
-    logger.info("All dependencies")
+    println("All dependencies")
     symbolTable.symbols.toList.sortBy(_.name).foreach { keySymbol =>
       val dependents = symbolTable.childrenOf.reachableFrom(keySymbol)
 
-      logger.info(s"${keySymbol.name} => ${dependents.map(_.name).mkString(",")}")
+      println(s"${keySymbol.name} => ${dependents.map(_.name).mkString(",")}")
     }
 
     tester.poke("io_in1", 7)
@@ -149,11 +148,11 @@ class SymbolTableSpec extends AnyFreeSpec with Matchers with LazyLogging {
 
     childrenOf.reachableFrom(symbolTable("io_in1")) should not contain symbolTable("io_out1")
 
-    logger.info("All dependencies")
+    println("All dependencies")
     symbolTable.symbols.toList.sortBy(_.name).foreach { keySymbol =>
       val dependents = symbolTable.childrenOf.reachableFrom(keySymbol)
 
-      logger.info(s"${keySymbol.name} => ${dependents.map(_.name).mkString(",")}")
+      println(s"${keySymbol.name} => ${dependents.map(_.name).mkString(",")}")
     }
 
     tester.poke("io_in1", 7)
@@ -209,8 +208,8 @@ class SymbolTableSpec extends AnyFreeSpec with Matchers with LazyLogging {
       .toList
       .sortBy(_.cardinalNumber)
 
-    logger.info("Input dependencies")
-    logger.info(inputChildren.map(s => s"${s.name}:${s.cardinalNumber}").mkString(","))
+    println("Input dependencies")
+    println(inputChildren.map(s => s"${s.name}:${s.cardinalNumber}").mkString(","))
 
     tester.poke("io_in1", 0)
     tester.poke("io_in2", 0)
@@ -264,8 +263,6 @@ class SymbolTableSpec extends AnyFreeSpec with Matchers with LazyLogging {
          |    io_out1 <= sub.out1
        """.stripMargin
 
-
-    Logger.setLevel(LogLevel.None)
     val outputBuffer = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputBuffer)) {
       try {


### PR DESCRIPTION
When found during symbol table processing It displays a combinational loop
(which will just be the first one found, if there are more than one).
The path contains the statements and the @INFO path with symbols on path in red
If a combinational loop is found by CheckComboLoops and you want to see this enhanced display, turn off the combination loop checking with an annotation or command line flag.
DontCheckCombLoopsAnnotation or --no-check-comb-loops