### PR TITLE
Additional changes for combinational loop reports

### DIFF
--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -95,15 +95,17 @@ class ExpressionViewRenderer(
             case ev: ExpressionView =>
               ev.args.head match {
                 case ms: Symbol =>
-                  val arg = args.drop(if (dataStore(ms) > 0) 2 else 1).head
-                  arg match {
-                    case ev2: ExpressionView =>
-                      ev2.args.head match {
-                        case sss: Symbol =>
-                          symbolsSeen += sss
-                        case _ =>
-                      }
-                    case _ =>
+                  if (showValues) {
+                    val arg = args.drop(if (dataStore(ms) > 0) 2 else 1).head
+                    arg match {
+                      case ev2: ExpressionView =>
+                        ev2.args.head match {
+                          case sss: Symbol =>
+                            symbolsSeen += sss
+                          case _ =>
+                        }
+                      case _ =>
+                    }
                   }
                 case value: Big =>
                   val arg = args.drop(if (value > 0) 2 else 1).head
@@ -151,7 +153,11 @@ class ExpressionViewRenderer(
             }
           }
 
-          val value = symbol.normalize(dataArrays.getValueAtIndex(symbol.dataSize, symbol.index))
+          val value = if (showValues) {
+            symbol.normalize(dataArrays.getValueAtIndex(symbol.dataSize, symbol.index))
+          } else {
+            BigInt(0)
+          }
 
           val string = s"${symbol.name}" + (if (showValues) {
                                               " <= " +

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -21,9 +21,9 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import firrtl.graph.CyclicException
 import firrtl.stage.FirrtlSourceAnnotation
 import firrtl.transforms.DontCheckCombLoopsAnnotation
-import treadle._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import treadle._
 
 //scalastyle:off magic.number
 class SymbolTableSpec extends AnyFreeSpec with Matchers {
@@ -273,5 +273,6 @@ class SymbolTableSpec extends AnyFreeSpec with Matchers {
       }
     }
     outputBuffer.toString.contains(s"io_out1 <= pad(${Console.RED}sub.out1${Console.RED_B})")
+    println(outputBuffer.toString)
   }
 }


### PR DESCRIPTION
This contains fixes to complete the rendering of
combinational loops that includes statements with highlighting of symbols along the loop.
Fixes rendering dependencies on rollback buffer sizes which should not matter for combo loops