### PR TITLE
Provide a way to save lowered Firrtl file

### DIFF
--- a/src/main/scala/treadle/TreadleOptions.scala
+++ b/src/main/scala/treadle/TreadleOptions.scala
@@ -16,11 +16,11 @@ limitations under the License.
 
 package treadle
 
-import firrtl.{ChirrtlForm, CircuitForm, CircuitState, HighForm, LowForm, UnknownForm}
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
 import firrtl.ir.Circuit
 import firrtl.options.{HasShellOptions, RegisteredLibrary, ShellOption, Unserializable}
 import firrtl.stage.{FirrtlFileAnnotation, FirrtlSourceAnnotation}
+import firrtl.{ChirrtlForm, CircuitForm, CircuitState, HighForm, LowForm, UnknownForm}
 import treadle.executable.{ClockInfo, DataStorePlugin, ExecutionEngine, TreadleException}
 
 sealed trait TreadleOption extends Unserializable { this: Annotation =>
@@ -34,7 +34,7 @@ case object WriteVcdAnnotation extends NoTargetAnnotation with TreadleOption wit
     new ShellOption[Unit](
       longOption = "tr-write-vcd",
       toAnnotationSeq = _ => Seq(WriteVcdAnnotation),
-      helpText = "writes vcd executioin log, filename will be based on top-name"
+      helpText = "writes vcd execution log, filename will be based on top-name"
     )
   )
 }
@@ -100,8 +100,21 @@ case object ShowFirrtlAtLoadAnnotation extends NoTargetAnnotation with TreadleOp
   val options: Seq[ShellOption[_]] = Seq(
     new ShellOption[Unit](
       longOption = "tr-show-firrtl-at-load",
-      toAnnotationSeq = _ => Seq(),
+      toAnnotationSeq = _ => Seq(ShowFirrtlAtLoadAnnotation),
       helpText = "show the low firrtl source treadle is using to build simulator"
+    )
+  )
+}
+
+/**
+  *  Tells treadle to show the low firrtl it is starting out with
+  */
+case object SaveFirrtlAtLoadAnnotation extends NoTargetAnnotation with TreadleOption with HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "tr-save-firrtl-at-load",
+      toAnnotationSeq = _ => Seq(SaveFirrtlAtLoadAnnotation),
+      helpText = "save the low firrtl source treadle is using to build simulator"
     )
   )
 }
@@ -340,6 +353,7 @@ class TreadleLibrary extends RegisteredLibrary {
     AllowCyclesAnnotation,
     RandomSeedAnnotation,
     ShowFirrtlAtLoadAnnotation,
+    SaveFirrtlAtLoadAnnotation,
     DontRunLoweringCompilerLoadAnnotation,
     ValidIfIsRandomAnnotation,
     RollBackBuffersAnnotation,

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -16,7 +16,11 @@ limitations under the License.
 
 package treadle.executable
 
+import java.io.PrintWriter
+
 import firrtl.ir.{Circuit, NoInfo}
+import firrtl.options.StageOptions
+import firrtl.options.Viewer.view
 import firrtl.{AnnotationSeq, PortKind}
 import treadle._
 import treadle.chronometry.{Timer, UTC}
@@ -47,10 +51,6 @@ class ExecutionEngine(
   )
 
   scheduler.executionEngineOpt = Some(this)
-
-  if (annotationSeq.collectFirst { case ShowFirrtlAtLoadAnnotation => ShowFirrtlAtLoadAnnotation }.isDefined) {
-    println(ast.serialize)
-  }
 
   val symbolsPokedSinceEvaluation: mutable.HashSet[Symbol] = new mutable.HashSet
 
@@ -475,8 +475,21 @@ object ExecutionEngine {
   def apply(annotationSeq: AnnotationSeq, wallTime: UTC): ExecutionEngine = {
     val timer = new Timer
     val t0 = System.nanoTime()
+    val stageOptions = view[StageOptions](annotationSeq)
 
     val circuit = annotationSeq.collectFirst { case TreadleCircuitStateAnnotation(c)           => c }.get.circuit
+
+    if (annotationSeq.contains(ShowFirrtlAtLoadAnnotation)) {
+      println(circuit.serialize)
+    }
+
+    if (annotationSeq.contains(SaveFirrtlAtLoadAnnotation)) {
+      val fileName = stageOptions.getBuildFileName(circuit.main, Some(".treadle.lo.fir"))
+      val writer = new PrintWriter(fileName)
+      writer.println(circuit.serialize)
+      writer.close()
+    }
+
     val blackBoxFactories = annotationSeq.collectFirst { case BlackBoxFactoriesAnnotation(bbf) => bbf }.getOrElse(
       Seq.empty
     )

--- a/src/test/scala/treadle/ShowLoweredFirrtlSpec.scala
+++ b/src/test/scala/treadle/ShowLoweredFirrtlSpec.scala
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle
+
+import java.io.File
+
+import firrtl.options.TargetDirAnnotation
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ShowLoweredFirrtlSpec extends AnyFreeSpec with Matchers {
+  "provides a way to save off lowered firrtl that treadle will run on" in {
+    val input =
+      """
+        |circuit DummyCircuit :
+        |  module DummyCircuit :
+        |    input reset : UInt<1>
+        |    input in1 : UInt<2>
+        |    output out1 : UInt<2>
+        |    output out2 : UInt<2>
+        |
+        |    out1 <= in1
+        |    node T_1 = add(out1, UInt<1>("h1"))
+        |    out2 <= T_1
+      """.stripMargin
+
+    val directory = "test_run_dir/saved_low_firrtl"
+    val firrtlFile = new File(s"$directory/DummyCircuit.treadle.lo.fir")
+    if (firrtlFile.exists) {
+      firrtlFile.delete()
+    }
+    TreadleTester(Seq(FirrtlSourceAnnotation(input), SaveFirrtlAtLoadAnnotation, TargetDirAnnotation(directory)))
+
+    firrtlFile.exists() should be(true)
+  }
+}


### PR DESCRIPTION
This adds SaveFirrtlAtLoadAnnotation as a way to see the lowered firrtl file that will be used by Treadle.
Formerly it would just dump file to stdout when ShowFirrtlAtLoadAnnotation was used.
Adds test to show that this works.
Fixed broken command line adding of ShowFirrtlAtLoadAnnotation
One small typo fix in WriteVcdAnnotation