### PR TITLE
Another attempt to have ScalaSteward ignore chisel dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,8 +73,11 @@ assemblyOutputPath in assembly := file("./utils/bin/treadle.jar")
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map("firrtl" -> "1.4-SNAPSHOT")
 
+// Ignore dependencies on Berkeley artifacts.
+// scala-steward:off
 libraryDependencies ++= (Seq("firrtl").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
+// scala-steward:on
 
 // sbt 1.2.6 fails with `Symbol 'term org.junit' is missing from the classpath`
 // when compiling tests under 2.11.12


### PR DESCRIPTION
Since the .scala-steward.conf file doesn't appear to be working (as far as ignoring Berkeley artifacts goes), try the technique mentioned in https://github.com/fthomas/scala-steward/blob/d8e1fd39007fefdb251ec0f07887964cd75a0962/docs/repo-specific-configuration.md
