### PR TITLE
This adds the ability to log memory changes to vcd output

### DIFF
--- a/src/main/scala/treadle/TreadleOptions.scala
+++ b/src/main/scala/treadle/TreadleOptions.scala
@@ -163,7 +163,18 @@ case object RollBackBuffersAnnotation extends HasShellOptions {
 }
 
 /**
-  *  Sets the number of rollback buffers in simulator, useful to see why wires have their values
+  *  Controls whether changes to memory locations are written to vcd output
+  *  @param specifier controls which memories and which locations of those memories are logged to vcd output
+  *                   When not present not memories are logged
+  *                   "all"             log all values at all locations of all memories
+  *                   "mem1:all"        log all values at all locations for memory mem1
+  *                   "mem1:0-4"        log values at locations 0-4 for memory mem1
+  *                   "mem1:b0-b100"    log values at locations 0-4 but show addresses in binary for memory mem1
+  *                   "mem1:h0-hff"     log values at locations 0-255 but show addresses in hex for memory mem1
+  *                   "mem1:o0-o377"    log values at locations 0-255 but show addresses in octal for memory mem1
+  *
+  * This annotation may occur more than once in order to specify multiple memories
+  *
   */
 case class MemoryToVCD(specifier: String)
   extends NoTargetAnnotation

--- a/src/main/scala/treadle/TreadleOptions.scala
+++ b/src/main/scala/treadle/TreadleOptions.scala
@@ -149,7 +149,7 @@ case object ValidIfIsRandomAnnotation extends NoTargetAnnotation with TreadleOpt
   *  Sets the number of rollback buffers in simulator, useful to see why wires have their values
   */
 case class RollBackBuffersAnnotation(rollbackBufferDepth: Int = TreadleDefaults.RollbackBuffers)
-    extends NoTargetAnnotation
+  extends NoTargetAnnotation
     with TreadleOption
 
 case object RollBackBuffersAnnotation extends HasShellOptions {
@@ -158,6 +158,23 @@ case object RollBackBuffersAnnotation extends HasShellOptions {
       longOption = "tr-rollback-buffers",
       toAnnotationSeq = (buffers: Int) => Seq(RollBackBuffersAnnotation(buffers)),
       helpText = s"number of rollback buffers, 0 is no buffers, default is ${TreadleDefaults.RollbackBuffers}"
+    )
+  )
+}
+
+/**
+  *  Sets the number of rollback buffers in simulator, useful to see why wires have their values
+  */
+case class MemoryToVCD(specifier: String)
+  extends NoTargetAnnotation
+    with TreadleOption
+
+case object MemoryToVCD extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "tr-mem-to-vcd",
+      toAnnotationSeq = (specifier: String) => Seq(MemoryToVCD(specifier)),
+      helpText = s"""log specified memory/indices to vcd, format "all" or "memoryName:1,2,5-10" """
     )
   )
 }

--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -18,6 +18,8 @@ package treadle
 
 import java.io.{File, PrintWriter}
 
+import treadle.utils.NumberHelpers._
+
 import firrtl.AnnotationSeq
 import firrtl.graph.{CyclicException, DiGraph}
 import firrtl.options.Viewer.view
@@ -206,21 +208,6 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
       case e: Exception =>
         console.println(s"Failed to load vcd script $fileName, error: ${e.getMessage}")
     }
-  }
-
-  def parseNumber(numberString: String): BigInt = {
-    def parseWithRadix(numString: String, radix: Int): BigInt = {
-      BigInt(numString, radix)
-    }
-
-    if (numberString.startsWith("0x")) { parseWithRadix(numberString.drop(2), 16) } else if (numberString.startsWith(
-                                                                                               "h"
-                                                                                             )) {
-      parseWithRadix(numberString.drop(1), 16)
-    } else if (numberString.startsWith("o")) { parseWithRadix(numberString.drop(1), 8) } else if (numberString
-                                                                                                    .startsWith("b")) {
-      parseWithRadix(numberString.drop(1), 2)
-    } else { parseWithRadix(numberString, 10) }
   }
 
   val wallTime = UTC()
@@ -620,7 +607,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
           getTwoArgs("poke inputSymbol value") match {
             case (Some(portName), Some(valueString)) =>
               try {
-                val numberValue = parseNumber(valueString)
+                val numberValue = parseBigInt(valueString)
                 engine.setValue(portName, numberValue)
               } catch {
                 case e: Exception =>
@@ -657,7 +644,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
                 if (valueString.toLowerCase == "clear") {
                   currentTreadleTester.clearForceValue(portName)
                 } else {
-                  val numberValue = parseNumber(valueString)
+                  val numberValue = parseBigInt(valueString)
                   currentTreadleTester.forceValue(portName, numberValue)
                 }
               } catch {
@@ -703,7 +690,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
           getTwoArgs("rpoke regex value") match {
             case (Some(pokeRegex), Some(valueString)) =>
               try {
-                val pokeValue = parseNumber(valueString)
+                val pokeValue = parseBigInt(valueString)
                 val portRegex = pokeRegex.r
                 val setThings = settableThings.flatMap { settableThing =>
                   portRegex.findFirstIn(settableThing) match {

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -74,6 +74,9 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
   val topName: String = annotationSeq.collectFirst { case OutputFileAnnotation(ofn) => ofn }.getOrElse(engine.ast.main)
   private val verbose = annotationSeq.exists { case VerboseAnnotation => true; case _ => false }
   private val stageOptions = view[StageOptions](annotationSeq)
+  private val memoryLogger: VcdMemoryLoggingController = {
+    VcdMemoryLoggingController(annotationSeq.collect { case MemoryToVCD(command) => command }, engine.symbolTable)
+  }
 
   def setVerbose(value: Boolean = true): Unit = {
     wallTime.isVerbose = value
@@ -155,7 +158,8 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
   if (writeVcd) {
     engine.makeVCDLogger(
       stageOptions.getBuildFileName(topName, Some(".vcd")),
-      vcdShowUnderscored
+      vcdShowUnderscored,
+      memoryLogger
     )
   }
 

--- a/src/main/scala/treadle/executable/DataStorePlugIn.scala
+++ b/src/main/scala/treadle/executable/DataStorePlugIn.scala
@@ -94,7 +94,7 @@ class RenderComputations(
   }
 }
 
-class VcdHook(val executionEngine: ExecutionEngine) extends DataStorePlugin {
+class VcdHook(val executionEngine: ExecutionEngine, memoryLogger: VcdMemoryLoggingController) extends DataStorePlugin {
   val dataStore: DataStore = executionEngine.dataStore
 
   override def run(symbol: Symbol, offset: Int = -1, previousValue: BigInt): Unit = {
@@ -102,6 +102,14 @@ class VcdHook(val executionEngine: ExecutionEngine) extends DataStorePlugin {
       val value = dataStore(symbol)
       executionEngine.vcdOption.foreach { vcd =>
         vcd.wireChanged(symbol.name, value, width = symbol.bitWidth)
+      }
+    } else {
+      val x = memoryLogger.vcdKey(symbol, offset)
+      x.foreach { memoryLocationName =>
+        val value = dataStore(symbol, offset)
+        executionEngine.vcdOption.foreach { vcd =>
+          vcd.wireChanged(memoryLocationName, value, width = symbol.bitWidth)
+        }
       }
     }
   }

--- a/src/main/scala/treadle/executable/VcdMemoryLoggingController.scala
+++ b/src/main/scala/treadle/executable/VcdMemoryLoggingController.scala
@@ -24,7 +24,7 @@ import scala.util.matching.Regex
 
 /** Controls whether a given memory cell should be logged to vcd output
   * if logAllRadixOpt is defined then all indices for all memories should be logged
-  * otherwise if info has an entry then check the memory index
+  * otherwise if memory has an entry then check the memory index
   * if the set contains -1 then all indices should be logged for that memory
   *
   * @param logAllRadixOpt  if defined then log all memories using this radix
@@ -39,9 +39,13 @@ class VcdMemoryLoggingController(
     s"$name(${BigInt(index).toString(radix)})"
   }
 
-  /* generate a vcd element name for a given memory location
-     checking whether the memory and the particular offset is being tracked
-   */
+  /** generate a vcd element name for a given memory location
+    *  checking whether the memory and the particular offset is being tracked
+    *
+    * @param symbol memory symbol to find key for
+    * @param offset index being referenced for memory
+    * @return
+    */
   def vcdKey(symbol: Symbol, offset: Int): Option[String] = {
     logAllRadixOpt match {
       case Some(radix) =>
@@ -59,15 +63,26 @@ class VcdMemoryLoggingController(
     }
   }
 
-  /* Builds a list of all tracked memories and the locations within them that are tracked
-   */
+  /** Builds a list of all tracked memories and the locations within them that are tracked
+    * This is used to construct the VCD directory
+    *
+    * @param memorySymbol Memory symbol to generate tracked names for
+    * @return
+    */
   def getIndexedNames(memorySymbol: Symbol): Seq[String] = {
-    memoriesTracked.get(memorySymbol) match {
-      case Some(IndicesAndRadix(set, radix)) =>
-        set.map { offset =>
-          indexedName(memorySymbol.name, offset, radix)
-        }.toSeq
-      case None => Seq.empty
+    logAllRadixOpt match {
+      case Some(radix) =>
+        Seq.tabulate(memorySymbol.slots) { index =>
+          indexedName(memorySymbol.name, index, radix)
+        }
+      case _ =>
+        memoriesTracked.get(memorySymbol) match {
+          case Some(IndicesAndRadix(set, radix)) =>
+            set.map { offset =>
+              indexedName(memorySymbol.name, offset, radix)
+            }.toSeq
+          case None => Seq.empty
+        }
     }
   }
 }

--- a/src/main/scala/treadle/executable/VcdMemoryLoggingController.scala
+++ b/src/main/scala/treadle/executable/VcdMemoryLoggingController.scala
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle.executable
+
+import firrtl.MemKind
+import logger.LazyLogging
+import treadle.utils.NumberHelpers
+
+import scala.util.matching.Regex
+
+/** Controls whether a given memory cell should be logged to vcd output
+  * if logAllRadixOpt is defined then all indices for all memories should be logged
+  * otherwise if info has an entry then check the memory index
+  * if the set contains -1 then all indices should be logged for that memory
+  *
+  * @param logAllRadixOpt  if defined then log all memories using this radix
+  * @param memoriesTracked    map of memories to the set of indices that should be logged
+  */
+class VcdMemoryLoggingController(
+  logAllRadixOpt:  Option[Int] = None,
+  memoriesTracked: Map[Symbol, IndicesAndRadix] = Map.empty
+) {
+
+  private def indexedName(name: String, index: Int, radix: Int): String = {
+    s"$name(${BigInt(index).toString(radix)})"
+  }
+
+  /* generate a vcd element name for a given memory location
+     checking whether the memory and the particular offset is being tracked
+   */
+  def vcdKey(symbol: Symbol, offset: Int): Option[String] = {
+    logAllRadixOpt match {
+      case Some(radix) =>
+        Some(indexedName(symbol.name, offset, radix))
+      case _ =>
+        memoriesTracked.get(symbol) match {
+          case Some(IndicesAndRadix(set, radix)) =>
+            if (set.contains(-1) || set.contains(offset)) {
+              Some(indexedName(symbol.name, offset, radix))
+            } else {
+              None
+            }
+          case _ => None
+        }
+    }
+  }
+
+  /* Builds a list of all tracked memories and the locations within them that are tracked
+   */
+  def getIndexedNames(memorySymbol: Symbol): Seq[String] = {
+    memoriesTracked.get(memorySymbol) match {
+      case Some(IndicesAndRadix(set, radix)) =>
+        set.map { offset =>
+          indexedName(memorySymbol.name, offset, radix)
+        }.toSeq
+      case None => Seq.empty
+    }
+  }
+}
+
+object VcdMemoryLoggingController extends LazyLogging {
+  private val radixChars = "bodhx"
+  val GlobalRadix:        Regex = s"""all:?([$radixChars]?)""".r
+  val SymbolAllRegex:     Regex = s"""([^:]+):all:?([$radixChars]?)""".r
+  val SymbolIndicesRegex: Regex = """([^:]+):([^:]+)""".r
+
+  private def getGlobalRadix(commands: Seq[String]): Option[Int] = {
+    commands.collectFirst { case GlobalRadix(radix) => NumberHelpers.radixFromString(radix) }
+  }
+
+  /** Build a VcdMemoryLoggingController from a list of commands
+    *
+    * @param commands    a list of strings containing logging instructions
+    * @param symbolTable use to check for symbols that are memories
+    * @return
+    */
+  def apply(commands: Seq[String], symbolTable: SymbolTable): VcdMemoryLoggingController = {
+    getGlobalRadix(commands) match {
+      case Some(radix) =>
+        // if here we are logging all indices for all memories
+        new VcdMemoryLoggingController(Some(radix))
+      case _ =>
+        // if we are here we limiting to particular memories
+        val memorySymbols = symbolTable.symbols.filter(_.dataKind == MemKind)
+
+        def getEntry(
+          memoryRegex:     String,
+          indicesAndRadix: IndicesAndRadix
+        ): Option[(Symbol, IndicesAndRadix)] = {
+
+          val regex = memoryRegex.r
+          memorySymbols.find(memorySymbol => regex.findFirstIn(memorySymbol.name).isDefined) match {
+            case Some(memorySymbol) =>
+              Some(memorySymbol -> indicesAndRadix)
+            case None =>
+              throw TreadleException(s"MemoryToVCD pattern $memoryRegex did not match any memories")
+          }
+        }
+
+        new VcdMemoryLoggingController(
+          logAllRadixOpt = None,
+          commands.flatMap {
+            case SymbolAllRegex(memoryRegex, radix) =>
+              getEntry(memoryRegex, IndicesAndRadix(Set(-1), NumberHelpers.radixFromString(radix)))
+            case SymbolIndicesRegex(memoryRegex, indicesString) =>
+              val indicesAndRadix = NumberHelpers.parseIntRangeWithRadix(indicesString)
+              getEntry(memoryRegex, indicesAndRadix)
+
+          }.toMap
+        )
+    }
+  }
+}
+
+case class IndicesAndRadix(indices: Set[Int], radix: Int = 10)

--- a/src/main/scala/treadle/utils/NumberHelpers.scala
+++ b/src/main/scala/treadle/utils/NumberHelpers.scala
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle.utils
+
+import treadle.executable.{IndicesAndRadix, TreadleException}
+
+import scala.util.matching.Regex
+
+object NumberHelpers {
+
+  val RadixRangeRegex: Regex = s"""([^-]+)-([^-]+)""".r
+
+  /** Parse a string with an optional radix prefix and return the number and the radix
+    *
+    * @param numberString string representation of number with possible radix prefix
+    */
+  def parseBigIntWithRadix(numberString: String): (BigInt, Int) = {
+    def parseWithRadix(numString: String, radix: Int): (BigInt, Int) = {
+      (BigInt(numString, radix), radix)
+    }
+
+    val normalizedNumberString = numberString.replaceAll("""[\s_]+""", "")
+    if (normalizedNumberString.startsWith("0x")) {
+      parseWithRadix(normalizedNumberString.drop(2), 16)
+    } else if (normalizedNumberString.startsWith("x")) {
+      parseWithRadix(normalizedNumberString.drop(1), 16)
+    } else if (normalizedNumberString.startsWith("h")) {
+      parseWithRadix(normalizedNumberString.drop(1), 16)
+    } else if (normalizedNumberString.startsWith("o")) {
+      parseWithRadix(normalizedNumberString.drop(1), 8)
+    } else if (normalizedNumberString.startsWith("b")) {
+      parseWithRadix(normalizedNumberString.drop(1), 2)
+    } else if (normalizedNumberString.startsWith("d")) {
+      parseWithRadix(normalizedNumberString.drop(1), 10)
+    } else { parseWithRadix(normalizedNumberString, 10) }
+  }
+
+  /** Parse a string with an optional radix prefix and return the number
+    *
+    * @param numberString  string containing a number
+    */
+  def parseBigInt(numberString: String): BigInt = {
+    parseBigIntWithRadix(numberString)._1
+  }
+
+  /** Parses a list of numbers separated by commas and allowing ranges "x-y" in place of a number
+    * numbers must be positive, returns a list of indices and remembers the one radix used
+    * Examples 10-100 or o7-o11 or 0xAA-0xBB or hA1,hA2,hA3
+    *
+    * @param rangeString  A string list of numbers
+    */
+  def parseIntRangeWithRadix(rangeString: String): IndicesAndRadix = {
+    var radix = Option.empty[Int]
+    def checkAndSetRadix(foundRadix: Int): Unit = {
+      if (radix.isEmpty) {
+        radix = Some(foundRadix)
+      } else if (!radix.contains(foundRadix)) {
+        throw TreadleException(s"""More than one radix specified in "$rangeString" """)
+      }
+    }
+
+    val indices = rangeString
+      .split(",")
+      .foldLeft(Set.empty[Int]) {
+        case (set, RadixRangeRegex(startString, endString)) =>
+          val (start, radix1) = parseBigIntWithRadix(startString)
+          val (end, radix2) = parseBigIntWithRadix(endString)
+          if (radix1 != radix2) {
+            throw TreadleException(s"""Radices must match in string "$rangeString" """)
+          } else {
+            checkAndSetRadix(radix1)
+          }
+          if (start > end) {
+            throw TreadleException(s"""$start is not <= $end in "$rangeString" """)
+          }
+          set ++ (start.toInt to end.toInt)
+        case (set, numberString) =>
+          val (number, radix1) = parseBigIntWithRadix(numberString)
+          checkAndSetRadix(radix1)
+          set + number.toInt
+      }
+
+    IndicesAndRadix(indices, radix.get)
+  }
+
+  def radixFromString(radixCode: String): Int = {
+    if (radixCode == "b") {
+      2
+    } else if (radixCode == "o") {
+      8
+    } else if (radixCode == "h" || radixCode == "x") {
+      16
+    } else {
+      10
+    }
+  }
+}

--- a/src/test/scala/treadle/MemoryVcdSpec.scala
+++ b/src/test/scala/treadle/MemoryVcdSpec.scala
@@ -86,7 +86,7 @@ class MemoryVcdSpec extends AnyFreeSpec with Matchers {
           FirrtlSourceAnnotation(HasTwoMems),
           TargetDirAnnotation(dir),
           WriteVcdAnnotation,
-          VcdShowUnderScoredAnnotation,
+          VcdShowUnderScoredAnnotation
         ) ++
           annotationSeq
       )

--- a/src/test/scala/treadle/MemoryVcdSpec.scala
+++ b/src/test/scala/treadle/MemoryVcdSpec.scala
@@ -1,0 +1,205 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle
+
+import firrtl.options.TargetDirAnnotation
+import firrtl.stage.FirrtlSourceAnnotation
+import firrtl.{AnnotationSeq, FileUtils}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import treadle.executable.TreadleException
+
+class MemoryVcdSpec extends AnyFreeSpec with Matchers {
+  private val HasTwoMems =
+    s"""
+       |circuit a :
+       |  module a :
+       |    input clock : Clock
+       |    input reset : UInt<1>
+       |
+       |    input  data1_in    : UInt<8>
+       |    output data1_out   : UInt<3>
+       |    input  data2_in    : UInt<8>
+       |    output data2_out   : UInt<3>
+       |
+       |    reg cnt : UInt<8>, clock with : (reset => (reset, UInt<256>("h00")))
+       |    cnt <= add(cnt, UInt<1>("h01"))
+       |
+       |    mem memory1 :
+       |      data-type => UInt<8>
+       |      depth => 256
+       |      read-latency => 0
+       |      write-latency => 1
+       |      reader => r
+       |      writer => w
+       |
+       |    mem memory2 :
+       |      data-type => UInt<8>
+       |      depth => 256
+       |      read-latency => 0
+       |      write-latency => 1
+       |      reader => r
+       |      writer => w
+       |
+       |    data1_out         <= memory1.r.data
+       |    memory1.r.addr    <= cnt
+       |    memory1.r.en      <= UInt<1>("h01")
+       |    memory1.r.clk     <= clock
+       |
+       |    memory1.w.addr <= cnt
+       |    memory1.w.en   <= UInt<1>("h01")
+       |    memory1.w.mask <= UInt<1>("h01")
+       |    memory1.w.clk  <= clock
+       |    memory1.w.data <= data1_in
+       |
+       |    data2_out         <= memory2.r.data
+       |    memory2.r.addr    <= cnt
+       |    memory2.r.en      <= UInt<1>("h01")
+       |    memory2.r.clk     <= clock
+       |
+       |    memory2.w.addr <= cnt
+       |    memory2.w.en   <= UInt<1>("h01")
+       |    memory2.w.mask <= UInt<1>("h01")
+       |    memory2.w.clk  <= clock
+       |    memory2.w.data <= data1_in
+       |
+       |""".stripMargin
+
+  "memory vcd writing tests" - {
+    def runTest(dir: String, annotationSeq: AnnotationSeq): Unit = {
+      val tester = TreadleTester(
+        Seq(
+          FirrtlSourceAnnotation(HasTwoMems),
+          TargetDirAnnotation(dir),
+          WriteVcdAnnotation,
+          VcdShowUnderScoredAnnotation,
+        ) ++
+          annotationSeq
+      )
+
+      for (i <- 0 to 20) {
+        tester.poke("data1_in", i)
+        tester.poke("data2_in", i)
+        tester.step()
+      }
+      tester.finish
+    }
+
+    def checkResults(dir: String, shouldAppear: Seq[String], shouldNotAppear: Seq[String]): Boolean = {
+      val fileName = s"$dir/a.vcd"
+      val vcdText = FileUtils.getLines(fileName)
+
+      for (text <- shouldAppear) {
+        assert(vcdText.exists { line =>
+          line.contains(text)
+        }, s""""$text" should appear in $fileName""")
+      }
+
+      for (text <- shouldNotAppear) {
+        assert(!vcdText.exists { line =>
+          line.contains(text)
+        }, s""""$text" should NOT appear in $fileName""")
+      }
+
+      true
+    }
+
+    "memories are not include in vcd output by default" in {
+      val dir = "test_run_dir/memory_vcd_test_no_logging"
+      runTest(dir, Seq.empty)
+      checkResults(dir, Seq.empty, Seq("memory1(", "memory2("))
+    }
+
+    "all memories can be included with the command all" in {
+      val dir = "test_run_dir/memory_vcd_test_all"
+      runTest(dir, Seq(MemoryToVCD("all")))
+      checkResults(dir, Seq.tabulate(20) { i =>
+        s"memory1($i)"
+      } ++ Seq.tabulate(20) { i =>
+        s"memory2($i)"
+      }, Seq.empty)
+    }
+
+    "all of just one memory can be included with the command memoryName:all" in {
+      val dir = "test_run_dir/memory_vcd_test_all_memory1"
+      runTest(dir, Seq(MemoryToVCD("memory1:all")))
+      checkResults(dir, Seq.tabulate(20) { i =>
+        s"memory1($i)"
+      }, Seq.tabulate(20) { i =>
+        s"memory2($i)"
+      })
+    }
+
+    "specific indices of a given memory can be logged" in {
+      val dir = "test_run_dir/memory_vcd_test_selected"
+      runTest(dir, Seq(MemoryToVCD("memory1:0-4"), MemoryToVCD("memory2:10-14")))
+      checkResults(
+        dir,
+        Seq.tabulate(5) { i =>
+          s"memory1($i)"
+        } ++
+          Seq.tabulate(5) { i =>
+            s"memory2(${i + 10})"
+          },
+        Seq.tabulate(5) { i =>
+          s"memory2($i)"
+        } ++
+          Seq.tabulate(5) { i =>
+            s"memory1(${i + 10})"
+          }
+      )
+    }
+
+    "indices can be specified in hex and octal and binary" in {
+      val dir = "test_run_dir/memory_vcd_index_radix"
+      runTest(dir, Seq(MemoryToVCD("memory1:b11,b111"), MemoryToVCD("memory2:ha1,0xa2")))
+      checkResults(
+        dir,
+        Seq(
+          s"memory1(11)",
+          s"memory1(111)",
+          s"memory2(a1)",
+          s"memory2(a2)"
+        ),
+        Seq.empty
+      )
+    }
+
+    "throw a chisel exception if radices are changed within one memory" in {
+      val dir = "test_run_dir/memory_vcd_index_radix"
+      intercept [TreadleException] {
+        runTest(dir, Seq(MemoryToVCD("memory1:b11,x111")))
+      }
+    }
+
+    "throw a chisel exception memory not found" in {
+      val dir = "test_run_dir/memory_vcd_index_radix"
+      intercept [TreadleException] {
+        runTest(dir, Seq(MemoryToVCD("memory3:b11,b111")))
+      }
+    }
+
+    "throw a chisel exception if index ranges is bad" in {
+      val dir = "test_run_dir/memory_vcd_index_radix"
+      intercept [TreadleException] {
+        runTest(dir, Seq(MemoryToVCD("memory3:d77-d66")))
+      }
+    }
+
+
+  }
+}

--- a/src/test/scala/treadle/utils/NumberHelpersSpec.scala
+++ b/src/test/scala/treadle/utils/NumberHelpersSpec.scala
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle.utils
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import treadle.executable.IndicesAndRadix
+import treadle.utils.NumberHelpers._
+
+class NumberHelpersSpec extends AnyFreeSpec with Matchers {
+  "NumberHelpers" - {
+    "Can parse a radix code" in {
+      radixFromString("b") must be(2)
+      radixFromString("o") must be(8)
+      radixFromString("d") must be(10)
+      radixFromString("x") must be(16)
+      radixFromString("h") must be(16)
+      radixFromString("anything else") must be(10)
+    }
+
+    "parse string with radix and range of indices" in {
+      IndicesAndRadix(Set.empty).radix must be(10)
+      parseIntRangeWithRadix("10,20") must be(IndicesAndRadix(Set(10, 20)))
+      parseIntRangeWithRadix("o10,o20") must be(IndicesAndRadix(Set(8, 16), 8))
+      parseIntRangeWithRadix("0x10-0x20") must be(IndicesAndRadix(Seq.tabulate(17)(_ + 16).toSet, 16))
+    }
+
+    "parse bigint strings with leading radix string" in {
+      parseBigInt("b111") must be(BigInt(7))
+      parseBigInt("o377") must be(BigInt(255))
+      parseBigInt("hff") must be(BigInt(255))
+      parseBigInt("hff") must be(BigInt(255))
+      parseBigInt("xff") must be(BigInt(255))
+      parseBigInt("0xff") must be(BigInt(255))
+      parseBigInt("0x-ff") must be(BigInt(-255))
+    }
+
+    "parse bigint string with radix and return value and radix" in {
+      parseBigIntWithRadix("b111") must be(BigInt(7), 2)
+      parseBigIntWithRadix("377") must be(BigInt(377), 10)
+      parseBigIntWithRadix("o377") must be(BigInt(255), 8)
+      parseBigIntWithRadix("hff") must be(BigInt(255), 16)
+      parseBigIntWithRadix("hff") must be(BigInt(255), 16)
+      parseBigIntWithRadix("xff") must be(BigInt(255), 16)
+      parseBigIntWithRadix("0xff") must be(BigInt(255), 16)
+      parseBigIntWithRadix("0x-ff") must be(BigInt(-255), 16)
+    }
+  }
+}


### PR DESCRIPTION
Usage
  --tr-mem-to-vcd commands

Commands are of the form

```
all.               all indicies for all memories
all:h              all indices for all memories, indices rendered in hex
mem1:all           all indices for memory1
mem1:1,2,3,10-20    mem1 will only have listed indices logged
mem1:0x3,0x10-0x20  mem1 will only have listed indices logged, indices will be rendered in hex
```

tr-mem-to-vcd can appear multiple times on command line to specify other memories

MemoryToVCD annotations can be used instead of command line

- Creates a new VcdMemoryLoggingController that can track what should be logged
  - All memories and all indices can be specified
  - Specific memories and all indices can be specified
  - specific memories and specific ranges of indices can be specified
  - indices can be specified in a radix and that radix will be used for vcd serialization of memory index
- Some additional tools for handling of string to indices were collected in NumberHelpers
  - This was derived from some code in TreadleRepl which is now change to use the new object
- New options to control this logging
  - default is same as previous (no logging of memories)
  - --tr-mem-to-vcd "loggingcommand"
  - MemoryToVCD(loggingCommand)
  - multiple occurrences of command line flag and annotation are supported
- Records memory locations being logged to vcd directory
- Testing specification is provided