### PR TITLE
Ability to Randomize Registers and Memory

### DIFF
--- a/src/main/scala/treadle/TreadleOptions.scala
+++ b/src/main/scala/treadle/TreadleOptions.scala
@@ -251,7 +251,21 @@ case object ResetNameAnnotation extends HasShellOptions {
 }
 
 /**
-  *  Tells treadle to present random value when validIf's condition is off
+  *  Tells treadle to Randomize circuit at startup
+  */
+case object RandomizeAtStartupAnnotation extends NoTargetAnnotation with TreadleOption with HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "tr-randomize-at-startup",
+      toAnnotationSeq = _ => Seq(RandomizeAtStartupAnnotation),
+      helpText = "makes treadle do it's own randomization of circuit at startup"
+    )
+  )
+}
+
+/**
+  *  Tell treadle to call it's own internal reset at startup. This is typically handled by the
+  *  unit test framework and not needed for users
   */
 case object CallResetAtStartupAnnotation extends NoTargetAnnotation with TreadleOption with HasShellOptions {
   val options: Seq[ShellOption[_]] = Seq(

--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -106,7 +106,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
   var done = false
 
   var inScript = false
-  val scriptFactory = ScriptFactory(this)
+  val scriptFactory: ScriptFactory = ScriptFactory(this)
   var currentScript: Option[Script] = None
   val IntPattern:    Regex = """(-?\d+)""".r
 
@@ -210,7 +210,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
     }
   }
 
-  val wallTime = UTC()
+  val wallTime: UTC = UTC()
   wallTime.onTimeChange = () => {
     engine.vcdOption.foreach { vcd =>
       vcd.setTime(wallTime.currentTime)
@@ -803,16 +803,13 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
         }
       },
       new Command("randomize") {
-        def usage: (String, String) = ("randomize", "randomize all symbols except reset)")
+        def usage: (String, String) = ("randomize", "randomize all registers and memory values)")
         def run(args: Array[String]): Unit = {
-          for (symbol <- engine.symbols) {
-            try {
-              val newValue = makeRandom(symbol.firrtlType)
-              engine.setValue(symbol.name, newValue)
-            } catch {
-              case e: Exception =>
-                console.println(s"Error randomize: setting ${symbol.name}, error ${e.getMessage}")
-            }
+          getOneArg("randomize [seed]", Some("0")) match {
+            case Some(additionalSeedString) =>
+              val additionalSeed = additionalSeedString.toLong
+              engine.randomize(additionalSeed)
+            case _ =>
           }
         }
       },

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -56,7 +56,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
 
   treadle.random.setSeed(annotationSeq.collectFirst { case RandomSeedAnnotation(seed) => seed }.getOrElse(0L))
 
-  val wallTime = UTC()
+  val wallTime: UTC = UTC()
 
   val engine: ExecutionEngine = ExecutionEngine(annotationSeq, wallTime)
 
@@ -201,6 +201,10 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
           wallTime.runUntil(wallTime.currentTime + timeRaised)
       }
     }
+  }
+
+  def randomize(): Unit = {
+    engine.randomize()
   }
 
   def makeSnapshot(): Unit = {

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -21,13 +21,15 @@ import java.io.PrintWriter
 import firrtl.ir.{Circuit, NoInfo}
 import firrtl.options.StageOptions
 import firrtl.options.Viewer.view
-import firrtl.{AnnotationSeq, MemKind, PortKind}
+import firrtl.{AnnotationSeq, MemKind, PortKind, RegKind}
+import logger.LazyLogging
 import treadle._
 import treadle.chronometry.{Timer, UTC}
 import treadle.utils.Render
 import treadle.vcd.VCD
 
 import scala.collection.mutable
+import scala.util.Random
 
 //scalastyle:off magic.number number.of.methods
 class ExecutionEngine(
@@ -38,7 +40,7 @@ class ExecutionEngine(
   val scheduler:       Scheduler,
   val expressionViews: Map[Symbol, ExpressionView],
   val wallTime:        UTC
-) {
+) extends LazyLogging {
   val cycleTimeIncrement = 500
 
   var vcdOption:   Option[VCD] = None
@@ -56,6 +58,8 @@ class ExecutionEngine(
 
   var verbose: Boolean = false
   setVerbose(annotationSeq.exists { case VerboseAnnotation => true; case _ => false })
+
+  val userRandomSeed: Long = annotationSeq.collectFirst { case RandomSeedAnnotation(seed) => seed }.getOrElse(0L)
 
   var inputsChanged: Boolean = false
 
@@ -160,6 +164,40 @@ class ExecutionEngine(
     vcdOption.foreach { vcd =>
       vcd.write(vcdFileName)
     }
+  }
+
+  def randomize(additonalSeed: Long = 0L): Unit = {
+    val rand = new Random
+
+    val symbolsToDo: Seq[Symbol] = symbolTable.symbols.toSeq
+
+    symbolsToDo.foreach { symbol =>
+      rand.setSeed(symbol.name.hashCode + userRandomSeed + additonalSeed)
+      rand.setSeed(rand.nextLong())
+
+      def getRandomValue: BigInt = {
+        val big = BigInt(symbol.bitWidth, rand)
+        val newValue = if (symbol.dataType == SignedInt) {
+          symbol.makeSInt(big, symbol.bitWidth)
+        } else {
+          symbol.makeUInt(big, symbol.bitWidth)
+        }
+        newValue
+      }
+      if (symbol.dataKind == RegKind) {
+        val newValue = getRandomValue
+        logger.info(s"setting ${symbol.name} <= $newValue")
+        setValue(symbol.name, getRandomValue)
+      } else if (symbol.dataKind == MemKind) {
+        for (slot <- 0 until symbol.slots) {
+          val newValue = getRandomValue
+          logger.info(s"setting ${symbol.name}($slot) <= $newValue")
+          setValue(symbol.name, getRandomValue, offset = slot)
+        }
+      }
+
+    }
+    evaluateCircuit()
   }
 
   def renderComputation(symbolNames: String, outputFormat: String = "d", showValues: Boolean = true): String = {
@@ -486,7 +524,7 @@ object ExecutionEngine {
     val t0 = System.nanoTime()
     val stageOptions = view[StageOptions](annotationSeq)
 
-    val circuit = annotationSeq.collectFirst { case TreadleCircuitStateAnnotation(c)           => c }.get.circuit
+    val circuit = annotationSeq.collectFirst { case TreadleCircuitStateAnnotation(c) => c }.get.circuit
 
     if (annotationSeq.contains(ShowFirrtlAtLoadAnnotation)) {
       println(circuit.serialize)

--- a/src/main/scala/treadle/utils/NameBasedRandomNumberGenerator.scala
+++ b/src/main/scala/treadle/utils/NameBasedRandomNumberGenerator.scala
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle.utils
+
+import scala.util.Random
+
+class NameBasedRandomNumberGenerator {
+  val rand = new Random
+
+  /** This number is an experiment with generating random numbers that will be stable across
+    * different runs with respect to the provided names.
+    *
+    * @param name           name to base random number on
+    * @param deviationSeed  a seed to affect the number generated
+    * @param bitWidth       number of bits in the generated random number
+    * @return
+    */
+  def nextBigInt(name: String, deviationSeed: Long, bitWidth: Int): BigInt = {
+    rand.setSeed(name.hashCode + deviationSeed)
+    rand.setSeed(rand.nextLong())
+    rand.setSeed(rand.nextLong())
+    rand.nextLong
+    BigInt(bitWidth, rand)
+  }
+}

--- a/src/test/scala/treadle/RandomizeCircuit.scala
+++ b/src/test/scala/treadle/RandomizeCircuit.scala
@@ -1,0 +1,147 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle
+
+import firrtl.stage.FirrtlSourceAnnotation
+import logger.{LazyLogging, LogLevel, Logger}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import treadle.chronometry.Timer
+
+import scala.util.Random
+
+class RandomizeCircuit extends AnyFreeSpec with Matchers with LazyLogging {
+  val t = new Timer()
+
+  def method1: Unit = {
+    Random.setSeed(System.currentTimeMillis())
+    t("method1") {
+      val a = Array.tabulate(1000) { i =>
+        Random.nextInt()
+      }
+      val sum = a.sum
+      println(s"method1 sum $sum")
+    }
+  }
+
+  def method2: Unit = {
+    t("method2") {
+      val a = Array.tabulate(1000) { i =>
+        Random.setSeed(i)
+        Random.nextInt()
+      }
+      val sum = a.sum
+      println(s"method2 $sum")
+    }
+  }
+
+  "random numbers should behave properly" in {
+    method1
+    method2
+    method1
+    method2
+    t.clear()
+    for (i <- 0 to 10) {
+      method1
+      method2
+    }
+    println(t.report())
+  }
+
+  "circuits can be randomized" in {
+    val input =
+      s"""
+         |circuit ToBeRandomized :
+         |  module ToBeRandomized :
+         |    input clock : Clock
+         |    input reset : UInt<1>
+         |    output io_r_data : UInt<8>
+         |    input  io_r_addr : UInt<3>
+         |    input  io_r_en   : UInt<1>
+         |    input  io_w_data : UInt<8>
+         |    input  io_w_addr : UInt<3>
+         |    input  io_w_en   : UInt<1>
+         |    input  io_w_mask : UInt<1>
+         |    input  io_in_a   : UInt<16>
+         |    output io_out_a  : UInt<16>
+         |
+         |    mem m :
+         |      data-type => UInt<8>
+         |      depth => 5
+         |      read-latency => 1
+         |      write-latency => 1
+         |      reader => r
+         |      writer => w
+         |
+         |    io_r_data   <= m.r.data
+         |    m.r.addr    <= io_r_addr
+         |    m.r.en      <= io_r_en
+         |    m.r.clk     <= clock
+         |
+         |    m.w.data <= io_w_data
+         |    m.w.addr <= io_w_addr
+         |    m.w.en   <= io_w_en
+         |    m.w.mask <= io_w_mask
+         |    m.w.clk  <= clock
+         |
+         |    reg reg1 : UInt<16>, clock with : (reset => (reset, UInt(1)))
+         |    reg reg2 : UInt<16>, clock with : (reset => (reset, UInt(2)))
+         |    reg reg3 : UInt<16>, clock with : (reset => (reset, UInt(3)))
+         |    reg reg4 : UInt<16>, clock with : (reset => (reset, UInt(4)))
+         |
+         |    reg reg11 : UInt<16>, clock with : (reset => (reset, UInt(11)))
+         |    reg reg12 : UInt<16>, clock with : (reset => (reset, UInt(12)))
+         |
+         |    reg1 <= io_in_a
+         |    reg2 <= add(io_in_a, io_in_a)
+         |    reg3 <= add(io_in_a, UInt(1))
+         |    reg4 <= add(io_in_a, UInt(17))
+         |    node dog = and(reg1, reg2)
+         |    node cat = and(reg3, reg4)
+         |    reg11 <= dog
+         |    reg12 <= cat
+         |    node rat = xor(reg11, reg12)
+         |    io_out_a <= rat
+         |
+         |
+         |""".stripMargin
+
+    val tester = TreadleTester(
+      Seq(
+        FirrtlSourceAnnotation(input),
+        WriteVcdAnnotation
+      )
+    )
+    // Logger.setLevel(tester.engine.getClass, LogLevel.Info)
+    tester.poke("io_in_a", 7)
+    tester.step(10)
+
+    tester.randomize()
+
+    tester.step(10)
+
+    tester.reset(30)
+    tester.step(10)
+
+    tester.randomize()
+    tester.step(10)
+
+    tester.finish
+
+    // GO AND LOOK AT VCD
+  }
+}

--- a/src/test/scala/treadle/executable/SymbolSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolSpec.scala
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle.executable
+
+import firrtl.RegKind
+import firrtl.ir.{IntWidth, NoInfo, SIntType}
+import logger.LazyLogging
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+import scala.collection.mutable
+import scala.util.Random
+
+class SymbolSpec extends AnyFreeSpec with Matchers with LazyLogging {
+  "symbol information can be used to generate random values for SInt that will fill the range" in {
+    val s = Symbol("bob", SIntType(IntWidth(4)), RegKind, 1, NoInfo)
+
+    val rand = new Random
+    rand.setSeed(s.name.hashCode + 10)
+    val set = new mutable.HashSet[BigInt]
+    for (_ <- 0 to 1000) {
+      val randomBig = BigInt(4, rand)
+      val value = s.makeSInt(randomBig, 4)
+      set += value
+    }
+    logger.debug(s"value = ${set.toSeq.sorted.mkString(",")}")
+    (BigInt(-8) to BigInt(7)).forall(x => set.contains(x)) must be(true)
+  }
+}


### PR DESCRIPTION
Seeds are based on register/memory name hashCodes plus a user supplied seed.
This makes randomization deterministic over multiple runs.

Run  RandomizeCircuit and see that happens. Points of interest
Time Event
100  First randomize call
200  Reset
245  Second Randomize call