### PR TITLE
Increase Fidelity with Verilator Printf

### DIFF
--- a/src/main/scala/treadle/executable/PrintfOp.scala
+++ b/src/main/scala/treadle/executable/PrintfOp.scala
@@ -45,7 +45,7 @@ case class PrintfOp(
         case _ =>
           throw TreadleException(s"In printf got unknown result in arguments to printf ${string.toString}")
       }
-      val instantiatedString = executeVerilogPrint(formatString, currentArgValues)
+      val instantiatedString = executeVerilogPrint(currentArgValues)
       print(instantiatedString)
     }
 
@@ -86,7 +86,7 @@ case class PrintfOp(
           s = s.drop(offset + 1)
           s.headOption match {
             case Some('%') =>
-              outBuffer ++= "%"
+              outBuffer ++= "%%"
               s = s.tail
             case Some('b') =>
               filters += toBinary
@@ -109,7 +109,7 @@ case class PrintfOp(
             case Some('x') =>
               val maxValue = BigInt("1" * widths.head, 2)
               filters += makeHex(maxValue)
-              outBuffer ++= s"%0${(widths.head / 4) + 1}x"
+              outBuffer ++= s"%0${(widths.head + 3) / 4}x"
               widths = widths.tail
               s = s.tail
             case Some(_) =>
@@ -125,7 +125,7 @@ case class PrintfOp(
     (StringContext.treatEscapes(outBuffer.toString()), filters)
   }
 
-  def executeVerilogPrint(formatString: String, allArgs: Seq[BigInt]): String = {
+  def executeVerilogPrint(allArgs: Seq[BigInt]): String = {
     val processedArgs = allArgs.zip(filterFunctions).map { case (arg, filter) => filter(arg) }
     if (addWallTime) {
       val time = scheduler.executionEngineOpt match {

--- a/src/test/scala/treadle/PrintStopSpec.scala
+++ b/src/test/scala/treadle/PrintStopSpec.scala
@@ -155,7 +155,7 @@ class PrintStopSpec extends AnyFlatSpec with Matchers with LazyLogging {
 
     logger.debug(output.toString)
 
-    output.toString() should include("HELLO WORLD int '       7' hex '00000001f' SInt '      -2'")
+    output.toString() should include("HELLO WORLD int '       7' hex '0000001f' SInt '      -2'")
   }
 
   it should "support printf formatting with binary" in {
@@ -178,8 +178,8 @@ class PrintStopSpec extends AnyFlatSpec with Matchers with LazyLogging {
 
     logger.debug(output.toString)
 
-    output.toString() should include("char M int  7 hex 0ff SInt -2  111")
-    output.toString() should include("char 0 int  7 hex 0ff SInt -2 -111")
+    output.toString() should include("char M int  7 hex ff SInt -2  111")
+    output.toString() should include("char 0 int  7 hex ff SInt -2 -111")
 
   }
 

--- a/src/test/scala/treadle/PrintfCorrectnessSpec.scala
+++ b/src/test/scala/treadle/PrintfCorrectnessSpec.scala
@@ -107,4 +107,107 @@ class PrintfCorrectnessSpec extends AnyFreeSpec with Matchers with LazyLogging {
       outputString should include(targetLine)
     }
   }
+
+  "printf needs to support the valid data formats" in {
+    val input =
+      """
+        |circuit HasPrintf :
+        |  module HasPrintf :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |
+        |    input  a : UInt<16>
+        |    input  b : UInt<5>
+        |    output c : UInt<16>
+        |
+        |    printf(clock, UInt(1), "formats: %%b for binary   %b\n", a)
+        |    printf(clock, UInt(1), "formats: %%d for decimal  %d\n", a)
+        |    printf(clock, UInt(1), "formats: %%x for hex      %x\n", a)
+        |    printf(clock, UInt(1), "formats: %%x for hex      %x\n", b)
+        |
+        |    c <= a
+        |
+        |""".stripMargin
+
+    val outputBuffer = new ByteArrayOutputStream()
+    Console.withOut(new PrintStream(outputBuffer)) {
+      val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+      tester.poke("a", 0xabcd)
+      tester.poke("b", 0x3d)
+      tester.step()
+      tester.poke("a", 0x1)
+      tester.poke("b", 0x1)
+      tester.step()
+      tester.finish
+    }
+    val output = outputBuffer.toString
+    output.contains("formats: %b for binary   1010101111001101") should be(true)
+    output.contains("formats: %d for decimal   43981") should be(true)
+    output.contains("formats: %x for hex      abcd") should be(true)
+  }
+
+  "printf hex leading zeros should work properly" in {
+    for (width <- 1 to 16) {
+      val input =
+        s"""
+           |circuit PrintfHex$width :
+           |  module PrintfHex$width :
+           |    input clock : Clock
+           |    input reset : UInt<1>
+           |
+           |    input  a : UInt<$width>
+           |    output c : UInt<$width>
+           |
+           |    printf(clock, UInt(1), "formats: %%x for hex UInt<$width> => %x", a)
+           |
+           |    c <= a
+           |
+           |""".stripMargin
+
+      val outputBuffer = new ByteArrayOutputStream()
+      Console.withOut(new PrintStream(outputBuffer)) {
+        val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+        tester.poke("a", 0x01)
+        tester.step()
+        tester.finish
+      }
+      val output = outputBuffer.toString
+      val leadingZeroes = (width - 1) % 4
+      output.contains(f"hex UInt<$width> => ${"0" * leadingZeroes}1")
+    }
+  }
+
+  "printf hex leading zeros should work properly with SInt's also" in {
+    for (width <- 1 to 8) {
+      val input =
+        s"""
+           |circuit PrintfHex$width :
+           |  module PrintfHex$width :
+           |    input clock : Clock
+           |    input reset : UInt<1>
+           |
+           |    input  a : UInt<$width>
+           |    output c : UInt<$width>
+           |
+           |    printf(clock, UInt(1), "formats: %%x for hex UInt<$width> => %x\\n", a)
+           |
+           |    c <= a
+           |
+           |""".stripMargin
+
+      val outputBuffer = new ByteArrayOutputStream()
+      Console.withOut(new PrintStream(outputBuffer)) {
+        val tester = TreadleTester(Seq(FirrtlSourceAnnotation(input)))
+        val (start, stop) = extremaOfSIntOfWidth(width)
+        for (value <- start to stop) {
+          tester.poke("a", value)
+          tester.step()
+        }
+        tester.finish
+      }
+      val output = outputBuffer.toString
+      val leadingZeroes = (width - 1) % 4
+      output.contains(f"hex UInt<$width> => ${"0" * leadingZeroes}1")
+    }
+  }
 }


### PR DESCRIPTION
- Fixes a bug handling escaped percent (%%) in printf format string
- Removes a spurious leading zero when displaying hex format
- Gets the right number of leading zeroes in all cases in hex format
- Adds tests for the above
- Fixes some older tests with incorrect `should`s
- Remove unused parameter in internal function in PrintfOp