### PR TITLE
Fix unused import

### DIFF
--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -29,7 +29,6 @@ import treadle.utils.{NameBasedRandomNumberGenerator, Render}
 import treadle.vcd.VCD
 
 import scala.collection.mutable
-import scala.util.Random
 
 //scalastyle:off magic.number number.of.methods
 class ExecutionEngine(


### PR DESCRIPTION
Remove an unused import that is breaking Scaladoc generation.

Since Chisel3 now builds Treadle from source, Treadle needs to generate clean documentation. This is fixing the specific reason that https://app.circleci.com/pipelines/github/freechipsproject/chisel3/1925/workflows/0a062e7b-0b2a-4c44-bedb-7b08b8ef0702/jobs/7188/steps failed. However, a scaladoc block on Treadle should be added to Treadle CI if Treadle is using `-Xfatal-warnings`.