### PR TITLE
Add documentation building to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,10 @@ jobs:
         run: |
           versionDeps=$(gawk -f repo/.github/scripts/generateVersionOverrides.gawk deps)
           echo "versonDeps: $versionDeps"
+      - name: documentation
+        id: doc
+        run: cat /dev/null | sbt $versionDeps doc
+        working-directory: ./repo
       - name: test
         id: test
         run: cat /dev/null | sbt $versionDeps +test


### PR DESCRIPTION
Add a CI step to build the documentation. This should gate future PRs to prevent problems with `-Xfatal-warnings` causing Chisel3 CI to fail.

Note that this is expected to fail without https://github.com/freechipsproject/treadle/pull/224.