### PR TITLE
Implement a finish call for engine

### DIFF
--- a/src/main/scala/treadle/ScalaBlackBox.scala
+++ b/src/main/scala/treadle/ScalaBlackBox.scala
@@ -83,6 +83,12 @@ trait ScalaBlackBox {
     * Add any parameters to the black box implementation
     */
   def setParams(params: Seq[Param]): Unit = {}
+
+  /** Called by TreadleTester#finish
+    * override this method to perform any cleanup necessary
+    *
+    */
+  def finish(): Unit = {}
 }
 
 /**

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -451,6 +451,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
   }
 
   def finish: Boolean = {
+    engine.finish()
     engine.writeVCD()
     isOK
   }

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -497,6 +497,14 @@ class ExecutionEngine(
     lastStopResult.isDefined
   }
 
+  def finish(): Unit = {
+    symbols.foreach { symbol =>
+      symbolTable.getBlackboxImplementation(symbol).foreach { blackBox =>
+        blackBox.finish()
+      }
+    }
+  }
+
   def fieldsHeader: String = {
     "Buf " +
       symbolTable.keys.toArray.sorted.map { name =>

--- a/src/test/scala/treadle/blackboxes/BlackBoxFinishSpec.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxFinishSpec.scala
@@ -1,0 +1,104 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package treadle.blackboxes
+
+import firrtl.ir.Type
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import treadle._
+import treadle.executable._
+
+//scalastyle:off magic.number
+
+/**
+  * Illustrate a black box that has multiple outputs
+  * This one creates 3 outputs each with a different increment of the input
+  */
+class HasCustomFinish extends ScalaBlackBox {
+  override def name: String = "HasCustomFinish"
+  var myFactoryOpt: Option[HasCustomFinishFactory] = None
+
+  override def getOutput(inputValues: Seq[BigInt], tpe: Type, outputName: String): BigInt = {
+    BigInt(42) // always returns 42
+  }
+
+  override def clockChange(transition: Transition, clockName: String): Unit = {
+    if(transition == PositiveEdge) {
+      myFactoryOpt.get.clockUpCount += 1
+    }
+  }
+
+  override def outputDependencies(outputName: String): Seq[String] = {
+    Seq.empty
+  }
+
+  override def finish(): Unit = {
+    println(s"HasCustomFinish was saw ${myFactoryOpt.get.clockUpCount} clock cycles")
+  }
+}
+
+class HasCustomFinishFactory extends ScalaBlackBoxFactory {
+  var clockUpCount: Int = 0
+
+  override def createInstance(instanceName: String, blackBoxName: String): Option[ScalaBlackBox] = {
+    val newBlackBox = new HasCustomFinish
+    newBlackBox.myFactoryOpt = Some(this)
+    Some(add(newBlackBox))
+  }
+}
+
+class BlackBoxFinishSpec extends AnyFreeSpec with Matchers {
+  "this tests black box implementation that have multiple outputs" - {
+    val adderInput =
+      """
+        |circuit CustomFinishTest :
+        |  extmodule HasCustomFinish :
+        |    input clock : Clock
+        |    output out  : UInt<64>
+        |
+        |  module CustomFinishTest :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output out  : UInt<64>
+        |
+        |    inst fo of HasCustomFinish
+        |    fo.clock <= clock
+        |    out  <= fo.out
+      """.stripMargin
+
+    "each output should hold a different values" in {
+
+      val customFinishFactory = new HasCustomFinishFactory
+      val options = Seq(
+        BlackBoxFactoriesAnnotation(Seq(customFinishFactory)),
+        RandomSeedAnnotation(1L)
+      )
+
+      val tester = TreadleTester(FirrtlSourceAnnotation(adderInput) +: options)
+
+      for (i <- 0 until 10) {
+        tester.expect("out", BigInt(42))
+        tester.step()
+      }
+
+      tester.finish
+
+      customFinishFactory.clockUpCount should be >= 10
+    }
+  }
+}


### PR DESCRIPTION
This calls ScalaBlackBox#finish method allowing
for cleanup or file writing to take place at end of simulation.