### PR TITLE
Fix license info in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,8 +84,8 @@ lazy val publishSettings = Seq(
   pomExtra := (<url>http://chisel.eecs.berkeley.edu/</url>
   <licenses>
     <license>
-      <name>BSD-style</name>
-      <url>http://www.opensource.org/licenses/bsd-license.php</url>
+      <name>apache_v2</name>
+      <url>https://opensource.org/licenses/Apache-2.0</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
License reference in maven publishing info
now points to apache 2.0